### PR TITLE
Go stuff is not needed in release build action

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,17 +15,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Go modules cache
-        uses: actions/cache@v2.1.3
-        with:
-          path: /go/pkg
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Go modules sync
-        run: go mod tidy
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

