### PR TITLE
use `olm-operator.keda.sh` as `LeaderElectionID`

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "b670c7de.keda.sh",
+		LeaderElectionID:       "olm-operator.keda.sh",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

By mistake this was changed during #96 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

