### PR TITLE
disable 'replaces' field, as the testing bundle doesn't replace anything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ deploy-olm: bundle-build bundle-push index-build index-push
 deploy-olm-testing:
 	sed -i 's/keda/keda-test/' bundle/metadata/annotations.yaml
 	sed -i 's/keda.v${VERSION}/keda-test.v${VERSION}/' bundle/manifests/keda.clusterserviceversion.yaml
+	# disable 'replaces' field, as the testing bundle doesn't replace anything
+	sed -i 's/replaces: /# replaces: /' bundle/manifests/keda.clusterserviceversion.yaml
 
 	$(eval BUNDLE=$(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-olm-operator-bundle-testing:$(VERSION))
 	$(eval INDEX=$(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-olm-operator-index-testing:$(VERSION))


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

```
 time="2022-05-13T13:48:51Z" level=error msg="permissive mode disabled" bundles="[ghcr.io/kedacore/keda-olm-operator-bundle:main]" error="Invalid bundle keda.v2.7.0, bundle specifies a non-existent replacement keda.v2.6.0"
Error: Invalid bundle keda.v2.7.0, bundle specifies a non-existent replacement keda.v2.6.0
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

