### PR TITLE
dont delete olm ns after depl-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ ifeq ($(shell kubectl get namespaces | grep olm),)
 	kubectl create ns olm
 endif
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -ginkgo.v -coverprofile cover.out -test.type deployment -ginkgo.focus "Deploying KedaController manifest"
-	kubectl delete namespace olm
 
 ##@ Build
 


### PR DESCRIPTION
during deployment tests, the workflow gets stuck on deleting olm namespace -> specifically the namespace gets stuck in state "terminating". Since these run in separate containters, dont enforce olm namespace deletion -> the destruction of the container will take care of it