### PR TITLE
Remove extra kubectl invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,7 @@ test-functionality: manifests generate fmt vet envtest ## Test functionality.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -ginkgo.v -coverprofile cover.out -test.type functionality -ginkgo.focus "Testing functionality"
 
 test-deployment: manifests generate fmt vet envtest ## Test OLM deployment.
-ifeq ($(shell kubectl get namespaces | grep olm),)
-	kubectl create ns olm
-endif
+	kubectl create namespace olm --dry-run=client -o yaml | kubectl apply -f -
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -ginkgo.v -coverprofile cover.out -test.type deployment -ginkgo.focus "Deploying KedaController manifest"
 
 ##@ Build
@@ -191,9 +189,7 @@ index-push:
 
 .PHONY: deploy-olm	## Deploy bundle. -- build & bundle to update if changes were made to code
 deploy-olm: build bundle docker-build docker-push bundle-build bundle-push index-build index-push
-ifeq ($(shell kubectl get namespaces | grep keda),)
-	kubectl create namespace keda;
-endif
+	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply -f -
 	operator-sdk run bundle ${BUNDLE} --namespace keda
 
 .PHONY: deploy-olm-testing


### PR DESCRIPTION
Because make will run ifeq shell commands on every invocation, every target
causes kubectl to be invoked to list namespaces, even targets which never
would have reached the targets in question.  Instead, update such targets
to use kubectl apply instead of kubectl create so that creation will succeed
even if the namespace already exists.


### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)