### PR TITLE
Add support for Prometheus monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Uninstallation](#uninstallation)
     - [How to uninstall KEDA Controller](#how-to-uninstall-keda-controller)
     - [How to uninstall KEDA OLM Operator](#how-to-uninstall-keda-olm-operator)
+  - [Monitoring](#monitoring)
   - [Development](#development)
     - [Operator Framework](#operator-framework)
     - [Running locally](#running-locally)
@@ -336,6 +337,11 @@ In case of manual installation, run these commands:
 ```bash
 make undeploy
 ```
+
+## Monitoring
+This operator contains monitoring configuration to enable Prometheus metrics
+collection. ServiceMonitor and PodMonitor instances are created if the CRDs from
+the Monitoring API are available in the cluster.
 
 ## Development
 

--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -497,10 +497,12 @@ spec:
         - apiGroups:
           - monitoring.coreos.com
           resources:
+          - podmonitors
           - servicemonitors
           verbs:
           - create
           - get
+          - list
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -558,6 +560,10 @@ spec:
                     port: 8081
                   initialDelaySeconds: 25
                 name: keda-olm-operator
+                ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,10 @@ spec:
             limits:
               cpu: 500m
               memory: 1000Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -498,9 +498,11 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - podmonitors
           verbs:
           - create
           - get
+          - list
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -555,6 +557,10 @@ spec:
                     port: 8081
                   initialDelaySeconds: 25
                 name: keda-olm-operator
+                ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,10 +60,12 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - podmonitors
   - servicemonitors
   verbs:
   - create
   - get
+  - list
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/keda/2.9.3/manifests/keda.v2.9.3.clusterserviceversion.yaml
+++ b/keda/2.9.3/manifests/keda.v2.9.3.clusterserviceversion.yaml
@@ -483,9 +483,11 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - podmonitors
           verbs:
           - create
           - get
+          - list
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -538,6 +540,10 @@ spec:
                     port: 8081
                   initialDelaySeconds: 25
                 name: keda-olm-operator
+                ports:
+                  - containerPort: 8080
+                    name: http
+                    protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/resources/keda.yaml
+++ b/resources/keda.yaml
@@ -9247,3 +9247,53 @@ spec:
     namespace: keda
   version: v1beta1
   versionPriority: 100
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-operator-metrics
+  namespace: keda
+  labels:
+    app.kubernetes.io/name: keda-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keda-operator
+  endpoints:
+    - port: metrics
+      interval: 60s
+  namespaceSelector:
+    any: false
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-metrics-apiserver
+  namespace: keda
+  labels:
+    app.kubernetes.io/name: keda-metrics-apiserver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keda-metrics-apiserver
+  endpoints:
+    - port: http
+      interval: 60s
+  namespaceSelector:
+    any: false
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: keda-olm-operator
+  namespace: keda
+  labels:
+    name: keda-olm-operator
+spec:
+  selector:
+    matchLabels:
+      name: keda-olm-operator
+  podMetricsEndpoints:
+    - targetPort: 8080
+      path: /metrics
+      interval: 60s


### PR DESCRIPTION
This change introduces the setup to enable the metric collection if the monitoring CRDs are present in the cluster.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->


### Checklist

- [x ] Commits are signed with Developer Certificate of Origin (DCO)


