### PR TITLE
Use installed namespace if WATCH_NAMESPACE not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Only custom resource named `keda` in the namespace where the operator was
 installed (typically, `keda`) will trigger the installation, reconfiguration,
 or removal of the KEDA Controller resources.
 
+The operator will behave in this manner whether it is installed with the
+`AllNamespaces` or `OwnNamespace` install mode. While the operator more
+closely matches the `OwnNamespace` semantics, `AllNamespaces` is a
+supported installation mode to allow it to be installed to namespaces with
+existing `OperatorGroups` which require that installation mode.
+
 There should be only one KEDA Controller in the cluster.
 
 ### `KedaController` Spec
@@ -412,7 +418,7 @@ spec:
 ## Uninstallation
 
 ### How to uninstall KEDA Controller
-Locate installed `KEDA` Operator in `keda` namespace and then remove created `KedaController` resoure or simply delete the `KedaController` resource:
+Locate installed `KEDA` Operator in `keda` namespace and then remove created `KedaController` resource or simply delete the `KedaController` resource:
 
 ```bash
 kubectl delete -n keda -f config/samples/keda_v1alpha1_kedacontroller.yaml

--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -454,7 +454,11 @@ spec:
     `KedaController` resource, please refer to [KedaController Example](https://github.com/kedacore/keda-olm-operator#kedacontroller-spec)
     for more deatils on available options.\n\nOnly resource named `keda` in the namespace
     where the KEDA OLM Operator is installed (typically `keda`) will trigger the installation,
-    reconfiguration or removal of the KEDA Controller resource.\n\nThere could be
+    reconfiguration or removal of the KEDA Controller resource.\n\nThe operator will behave
+    in this manner whether it is installed with the AllNamespaces or OwnNamespace install
+    mode. While the operator more closely matches the OwnNamespace semantics, AllNamespaces
+    is a supported installation mode to allow it to be installed to namespaces with
+    existing OperatorGroups which require that installation mode.\n\nThere should be
     only one KEDA Controller in the cluster. \n"
   displayName: KEDA
   icon:
@@ -630,7 +634,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - keda

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -454,7 +454,11 @@ spec:
     `KedaController` resource, please refer to [KedaController Example](https://github.com/kedacore/keda-olm-operator#kedacontroller-spec)
     for more deatils on available options.\n\nOnly resource named `keda` in the namespace
     where the KEDA OLM Operator is installed (typically `keda`) will trigger the installation,
-    reconfiguration or removal of the KEDA Controller resource.\n\nThere could be
+    reconfiguration or removal of the KEDA Controller resource.\n\nThe operator will behave
+    in this manner whether it is installed with the AllNamespaces or OwnNamespace install
+    mode. While the operator more closely matches the OwnNamespace semantics, AllNamespaces
+    is a supported installation mode to allow it to be installed to namespaces with
+    existing OperatorGroups which require that installation mode.\n\nThere should be
     only one KEDA Controller in the cluster. \n"
   displayName: KEDA
   icon:
@@ -626,7 +630,7 @@ spec:
               serviceAccountName: keda-olm-operator
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
In #192 there was an attempt to change the CSV to change the installMode from `OwnNamepsace` to `AllNamespaces`, but that change was lost during the next bundle re-generation. This PR re-makes that change in both the config and the bundle, but allows the operator to be installed in either mode. This provides flexibility allowing the operator to be installed into existing namespaces, potentially with other operators present, where the `OperatorGroup` is already present and annotated to require one or the other.

With the installMode `AllNamespaces`, `WATCH_NAMESPACE` may not be set especially in cases where the operator is installed to an existing namespace with an existing `operatorgroup`.  This change allows the KEDA OLM operator to work whether it is run with a `WATCH_NAMESPACE`
env var or not.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)