### PR TITLE
Have relprep.sh check to see if bundle & manifest CSVs are in sync

### DIFF
--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -625,10 +625,17 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 100Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates
                   readOnly: true
+              securityContext:
+                runAsNonRoot: true
               serviceAccountName: keda-olm-operator
               volumes:
               - name: certificates

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -13,7 +13,6 @@ spec:
       labels:
         name: keda-olm-operator
     spec:
-      serviceAccountName: keda-olm-operator
       containers:
         - name: keda-olm-operator
           image: ghcr.io/kedacore/keda-olm-operator:main
@@ -32,6 +31,11 @@ spec:
             limits:
               cpu: 500m
               memory: 1000Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           ports:
             - containerPort: 8080
               name: http
@@ -53,6 +57,9 @@ spec:
           - mountPath: /certs
             name: certificates
             readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: keda-olm-operator
       volumes:
       - name: certificates
         secret:

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -569,7 +569,9 @@ spec:
           - list
         serviceAccountName: keda-olm-operator
       deployments:
-      - name: keda-olm-operator
+      - label:
+          app.kubernetes.io/part-of: keda-olm-operator
+        name: keda-olm-operator
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
Also:
* make CRD extraction more robust, to handle more than just examples.keda.sh CRDs
* notice when there are missing CRDs in the bundle generation inputs
* manually sync some of the manifest CSV fields and the inputs to the
  generated bundle CSV's fields so that the new check passes

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Notes for reviewers:
While doing the upstream 2.12.1 release, I noticed a little weirdness in the KEDA OLM operator's `hack/relprep.sh` script. Namely, that it isn't keeping `config/manifests/bases/keda.clusterserviceversion.yaml` and `bundle/manifests/keda.clusterserviceversion.yaml` in sync. Apparently, the former doesn't get updated by the `operator-sdk generate kustomize manifests -q` command like I thought it did, and the latter does get updated, but is only used for our manual testing workflow (when we're developing or doing a release). While playing around with it, I also did some test runs on 2.13.0 and noticed that there is a new CRD coming our way which lives in `eventing.keda.sh` instead of `keda.sh`, so that also broke the script. So I've opened a PR to "fix" all of that. I'm using quotes because some of the things aren't actually fixed by the script, only detected, so that a human knows which things to manually update. I didn't figure it was worth the work to automate them at this point, but we can always change our mind later if I'm wrong.