### PR TITLE
Fix keda-metrics-apiserver ServiceMonitor port

### DIFF
--- a/resources/keda-olm-operator.yaml
+++ b/resources/keda-olm-operator.yaml
@@ -39,7 +39,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: keda-metrics-apiserver
   endpoints:
-    - port: http
+    - port: metrics
       interval: 60s
   namespaceSelector:
     any: false


### PR DESCRIPTION
In our 2.11.2 release https://github.com/kedacore/keda-olm-operator/pull/205 we:
- retired the `9022` metrics port, and replaced it with `8080`, the old http port. 
- updated the service with the port name "metrics"

However: 
-  it looks like we missed updating the ServiceMonitor, which still references the port as "http"
- the prometheus target for `keda-metrics-apiserver` isn't working because it can't find a port named "http" anymore.

Therefore: 

- This updates the ServiceMonitor so the servicemonitor port name matches the service port name. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
