### PR TITLE
Update cosign-installer for main builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v2
+        uses: sigstore/cosign-installer@v3
 
       - name: Check Cosign install!
         run: cosign version


### PR DESCRIPTION
This should fix failures of main build workflow with errors like:

```
Error: signing [ghcr.io/kedacore/keda-olm-operator:main]: getting signer: getting key from Fulcio: verifying SCT: updating local metadata and targets: error updating to TUF remote mirror: invalid key
```