### PR TITLE
Prevent namespace creation/modification when installing via OLM

### DIFF
--- a/controllers/keda/kedacontroller_controller.go
+++ b/controllers/keda/kedacontroller_controller.go
@@ -263,10 +263,12 @@ func parseManifestsFromFile(manifest mf.Manifest, c client.Client) (manifestGene
 			}
 		case "Secret":
 			controllerResources = append(controllerResources, r)
-		case "Namespace", "ServiceAccount":
+		case "ServiceAccount":
 			generalResources = append(generalResources, r)
 		case "PodMonitor", "ServiceMonitor":
 			monitoringResources = append(monitoringResources, r)
+		case "Namespace":
+			// ignore. we don't need to create or label the namespace since it's a prereq for OLM install anyway
 		}
 	}
 


### PR DESCRIPTION
Since OLM installs the operator to an existing namespace, there is little (no?) value in having this operator try to manage the namespace where it is already running. Also, we have an apparent bug where we always create/manage the `keda` namespace even if the operator is running in a different namespace. 

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)