### PR TITLE
Set "readOnlyRootFilesystem: true" in operator pod template to match operand

### DIFF
--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ metadata:
     categories: Cloud Provider
     certified: "false"
     containerImage: ghcr.io/kedacore/keda-olm-operator:2.15.0
-    createdAt: "2024-08-09T21:40:07Z"
+    createdAt: "2024-08-12T20:57:13Z"
     description: Operator that provides KEDA, a Kubernetes-based event driver autoscaler
     operatorframework.io/suggested-namespace: keda
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
@@ -655,6 +655,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
             capabilities:
               drop:
               - ALL
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 8080
               name: http

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -652,6 +652,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/keda/2.14.1/manifests/keda.v2.14.1.clusterserviceversion.yaml
+++ b/keda/2.14.1/manifests/keda.v2.14.1.clusterserviceversion.yaml
@@ -630,6 +630,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/keda/2.15.0/manifests/keda.v2.15.0.clusterserviceversion.yaml
+++ b/keda/2.15.0/manifests/keda.v2.15.0.clusterserviceversion.yaml
@@ -652,6 +652,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates


### PR DESCRIPTION
- The operand's root is set to read only, but the operator isn't, which is causing things like the trivy scanner to complain about it as "severity high" misconfiguration:

```
   "Type": "Kubernetes Security Check",
              "ID": "KSV014",
              "AVDID": "AVD-KSV-0014",
              "Title": "Root file system is not read-only",
              "Description": "An immutable root file system prevents applications from writing to their local disk. This can limit intrusions, as attackers will not be able to tamper with the file system or write foreign executables to disk.",
              "Message": "Container 'custom-metrics-autoscaler-operator' of Pod 'custom-metrics-autoscaler-operator-5b6fb58767-zmrvr' should set 'securityContext.readOnlyRootFilesystem' to true",
              "Namespace": "builtin.kubernetes.KSV014",
              "Query": "data.builtin.kubernetes.KSV014.deny",
              "Resolution": "Change 'containers[].securityContext.readOnlyRootFilesystem' to 'true'.",
              "Severity": "HIGH",
              "PrimaryURL": "https://avd.aquasec.com/misconfig/ksv014",
              "References": [
                "https://kubesec.io/basics/containers-securitycontext-readonlyrootfilesystem-true/",
                "https://avd.aquasec.com/misconfig/ksv014"
              ],
              "Status": "FAIL",
```


- This just changes the readOnlyRootFilesystem setting to true in the pod templates (both the raw manifests and the CSV) to alleviate any possible security issue the writeable root fs may cause. It should have no impact whatsoever on the operation of the operator.

- I only changed the base template and the CSVs for 2.14.1 and 2.15.0, I figured it wasn't worth messing with all the old ones but I can go back further if need be

NOTE: I did re-run a trivy scan with a bundle built from this PR and this does fix the issue 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
