### PR TITLE
chore: migrate golangci-lint from v1 to v2 

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           go-version: '1.25'
       - name: Get golangci
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
       - uses: pre-commit/action@v3.0.1
 
   test-build:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,8 +33,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-      - name: Get golangci
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.10
+          install-only: true
       - uses: pre-commit/action@v3.0.1
 
   test-build:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 # options for analysis running
 run:
   # default concurrency is a available CPU number
@@ -5,20 +7,18 @@ run:
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
+
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  # In v2, 'disable-all: true' is replaced with 'default: none'
+  default: none
   enable:
-    - typecheck
+    # typecheck is now built-in and always enabled in v2
     - dupl
     - goprintffuncname
     - govet
     - nolintlint
     #- rowserrcheck
-    - gofmt
     - revive
-    - goimports
     - misspell
     - bodyclose
     - unconvert
@@ -29,20 +29,43 @@ linters:
     - dogsled
     - errcheck
     #- funlen
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gosimple
-    - stylecheck
+    # gosimple and stylecheck are now part of staticcheck in v2
     - unused
     - unparam
-    - unconvert
     - whitespace
+
+  settings:
+    funlen:
+      lines: 80
+      statements: 40
+    # copied from https://github.com/kedacore/keda/blob/1ab35e75a63b3b33ca59552dda93220fd916a05d/.golangci.yml#L163-L168
+    depguard: #https://github.com/kedacore/keda/issues/4980
+      rules:
+        main:
+          deny:
+            - pkg: sync/atomic
+              desc: "use type-safe atomics from go.uber.org/atomic"
+
+# In v2, formatters like gofmt, goimports, and gci are moved to the formatters section
+formatters:
+  enable:
+    - gofmt
+    - goimports
+    - gci
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/kedacore/keda)
 
 issues:
   include:
-  - EXC0002 # disable excluding of issues about comments from golint
+    - EXC0002 # disable excluding of issues about comments from golint
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: _test\.go
@@ -84,25 +107,8 @@ issues:
         - gocritic
       text: "unnecessaryDefer:"
     - linters:
-       - stylecheck
+        - staticcheck
       text: "ST1000:"
     # Exclude some linters from running on test files.
     - path: _test\.go$
       text: "dot-imports: should not use dot imports"
-
-linters-settings:
-  funlen:
-    lines: 80
-    statements: 40
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/kedacore/keda)
-  # copied from https://github.com/kedacore/keda/blob/1ab35e75a63b3b33ca59552dda93220fd916a05d/.golangci.yml#L163-L168
-  depguard: #https://github.com/kedacore/keda/issues/4980
-    rules:
-      main:
-        deny:
-          - pkg: sync/atomic
-            desc: "use type-safe atomics from go.uber.org/atomic"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,60 @@ linters:
           deny:
             - pkg: sync/atomic
               desc: "use type-safe atomics from go.uber.org/atomic"
+    revive:
+      rules:
+        # Disable rules that require comments on all exported types
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: var-naming
+          disabled: true
+
+  # Defines a set of rules to ignore issues
+  exclusions:
+    # Use presets for common exclusions
+    presets:
+      - comments
+      - std-error-handling
+      - common-false-positives
+    # Excluding configuration per-path, per-linter, per-text and per-source
+    rules:
+      - path: _test\.go
+        linters:
+          - gomnd
+          - dupl
+      # Exclude because: "string `Deployment` has 3 occurrences, but such constant `Deployment` already exists"
+      # but we don't need to make them constants
+      - path: internal/controller/keda/transform/transform\.go
+        linters:
+          - goconst
+      # Exclude because: "string `Deployment` has 3 occurrences, but such constant `Deployment` already exists"
+      # but we don't need to make them constants
+      - path: internal/controller/keda/kedacontroller_controller\.go
+        linters:
+          - goconst
+      # Exclude for controllers, reason:
+      # "internal/controller/configmap_controller.go:49: 49-80 lines are duplicate of `internal/controller/secret_controller.go:49-80`"
+      - path: _controller\.go
+        linters:
+          - dupl
+      # Exclude because: "internal/controller/suite_test.go:157:63: `getObject` - `namespace` always receives `namespace` (`"keda"`)"
+      - path: internal/controller/keda/suite_test\.go
+        linters:
+          - unparam
+          - goconst
+      # Exclude because: "declaration has 3 blank identifiers" -> it's ok, we don't need them
+      - path: resources/resources_handler\.go
+        linters:
+          - dogsled
+      # https://github.com/go-critic/go-critic/issues/926
+      - linters:
+          - gocritic
+        text: "unnecessaryDefer:"
+      - linters:
+          - staticcheck
+        text: "ST1000:"
 
 # In v2, formatters like gofmt, goimports, and gci are moved to the formatters section
 formatters:
@@ -61,54 +115,8 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/kedacore/keda)
+        - prefix(github.com/kedacore/keda-olm-operator)
 
-issues:
-  include:
-    - EXC0002 # disable excluding of issues about comments from golint
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-        - dupl
-    # Exclude because: "string `Deployment` has 3 occurrences, but such constant `Deployment` already exists"
-    # but we don't need to make them constants
-    - path: internal/controller/keda/transform/transform.go
-      linters:
-        - goconst
-    # Exclude because: "string `Deployment` has 3 occurrences, but such constant `Deployment` already exists"
-    # but we don't need to make them constants
-    # and:
-    # "exported: type name will be used as keda.KedaControllerReconciler by other packages, and that stutters;
-    # consider calling this ControllerReconciler (revive)"
-    - path: internal/controller/keda/kedacontroller_controller.go
-      linters:
-        - goconst
-        - revive
-    # Exclude for controllers, reason:
-    # "internal/controller/configmap_controller.go:49: 49-80 lines are duplicate of `internal/controller/secret_controller.go:49-80`"
-    - path: _controller.go
-      linters:
-        - dupl
-    # Exclude because: "internal/controller/suite_test.go:157:63: `getObject` - `namespace` always receives `namespace` (`"keda"`)"
-    - path: internal/controller/keda/suite_test.go
-      linters:
-        - unparam
-    # Exclude because: "declaration has 3 blank identifiers" -> it's ok, we don't need them
-    - path: resources/resources_handler.go
-      linters:
-        - dogsled
-    - path: cmd/main.go
-      linters:
-        - gci
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-    - linters:
-        - staticcheck
-      text: "ST1000:"
-    # Exclude some linters from running on test files.
-    - path: _test\.go$
-      text: "dot-imports: should not use dot imports"
+  exclusions:
+    paths:
+      - cmd/main\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,10 +9,8 @@ run:
   timeout: 10m
 
 linters:
-  # In v2, 'disable-all: true' is replaced with 'default: none'
   default: none
   enable:
-    # typecheck is now built-in and always enabled in v2
     - dupl
     - goprintffuncname
     - govet
@@ -32,7 +30,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    # gosimple and stylecheck are now part of staticcheck in v2
     - unused
     - unparam
     - whitespace
@@ -69,7 +66,6 @@ linters:
     rules:
       - path: _test\.go
         linters:
-          - gomnd
           - dupl
       # Exclude because: "string `Deployment` has 3 occurrences, but such constant `Deployment` already exists"
       # but we don't need to make them constants
@@ -95,15 +91,10 @@ linters:
       - path: resources/resources_handler\.go
         linters:
           - dogsled
-      # https://github.com/go-critic/go-critic/issues/926
-      - linters:
-          - gocritic
-        text: "unnecessaryDefer:"
       - linters:
           - staticcheck
         text: "ST1000:"
 
-# In v2, formatters like gofmt, goimports, and gci are moved to the formatters section
 formatters:
   enable:
     - gofmt

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,24 +23,27 @@ import (
 	"runtime"
 	"strings"
 
-	routev1 "github.com/openshift/api/route/v1"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	routev1 "github.com/openshift/api/route/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
 	kedacontrollers "github.com/kedacore/keda-olm-operator/internal/controller/keda"
 	"github.com/kedacore/keda-olm-operator/version"
+	//+kubebuilder:scaffold:imports
 )
 
 var (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,27 +23,24 @@ import (
 	"runtime"
 	"strings"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	routev1 "github.com/openshift/api/route/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
 	kedacontrollers "github.com/kedacore/keda-olm-operator/internal/controller/keda"
 	"github.com/kedacore/keda-olm-operator/version"
-	//+kubebuilder:scaffold:imports
 )
 
 var (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,10 +26,10 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"

--- a/internal/controller/keda/configmap_controller.go
+++ b/internal/controller/keda/configmap_controller.go
@@ -88,7 +88,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Fetch the ConfigMap instance
 	instance := &corev1.ConfigMap{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -101,7 +101,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	kedaController := &kedav1alpha1.KedaController{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "keda", Namespace: r.installNamespace}, kedaController)
+	err = r.Get(ctx, types.NamespacedName{Name: "keda", Namespace: r.installNamespace}, kedaController)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// there isn't any keda KedaController CR created in namespace keda -> do nothing

--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -135,7 +135,7 @@ func (r *KedaControllerReconciler) ensureKedaController(logger logr.Logger) {
 
 	// Fetch operator namespace
 	kedaNamespace := &corev1.Namespace{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: r.resourceNamespace}, kedaNamespace)
+	err := r.Get(ctx, types.NamespacedName{Name: r.resourceNamespace}, kedaNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.Error(err, "Keda namespace not found.")
@@ -150,12 +150,12 @@ func (r *KedaControllerReconciler) ensureKedaController(logger logr.Logger) {
 
 	// If operator namespace is not annotated, annotate and create a default KedaController if one doesn't exist
 	if _, ok := annotations[kedaDefaultControllerAnnotation]; !ok {
-		err = r.Client.Get(ctx, types.NamespacedName{Name: kedaControllerResourceName, Namespace: r.resourceNamespace}, &kedav1alpha1.KedaController{})
+		err = r.Get(ctx, types.NamespacedName{Name: kedaControllerResourceName, Namespace: r.resourceNamespace}, &kedav1alpha1.KedaController{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				logger.Info("KedaController does not exist. Creating default KedaController resource")
 				instance := r.initializeDefaultController()
-				err = r.Client.Create(ctx, instance)
+				err = r.Create(ctx, instance)
 				if err != nil {
 					logger.Error(err, "Error creating default KedaController")
 					return
@@ -176,7 +176,7 @@ func (r *KedaControllerReconciler) ensureKedaController(logger logr.Logger) {
 
 		annotations[kedaDefaultControllerAnnotation] = "true"
 		kedaNamespaceCopy.SetAnnotations(annotations)
-		err = r.Client.Patch(ctx, kedaNamespaceCopy, client.StrategicMergeFrom(kedaNamespace))
+		err = r.Patch(ctx, kedaNamespaceCopy, client.StrategicMergeFrom(kedaNamespace))
 		if err != nil {
 			logger.Error(err, "Error patching namespace with annotation for default KedaController creation")
 			return
@@ -224,7 +224,7 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Fetch the KedaController instance
 	instance := &kedav1alpha1.KedaController{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -256,7 +256,7 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			// removed, the object will be deleted.
 			patch := client.MergeFrom(instance.DeepCopy())
 			instance.SetFinalizers(remove(instance.GetFinalizers(), kedaControllerFinalizer))
-			err := r.Client.Patch(ctx, instance, patch)
+			err := r.Patch(ctx, instance, patch)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -668,8 +668,8 @@ func (r *KedaControllerReconciler) installMetricsServer(ctx context.Context, log
 
 	// Audit logging validation - configMap exists, logOutVolumeClaim validation
 	// policy is a wrapper AuditPolicy for auditv1.Policy for easier user exposure
-	policy := instance.Spec.MetricsServer.AuditConfig.Policy
-	logOutVolumeClaim := instance.Spec.MetricsServer.AuditConfig.LogOutputVolumeClaim
+	policy := instance.Spec.MetricsServer.Policy
+	logOutVolumeClaim := instance.Spec.MetricsServer.LogOutputVolumeClaim
 
 	// if policy is not empty, audit logging is ON
 	if !reflect.DeepEqual(policy, kedav1alpha1.AuditPolicy{}) {
@@ -687,7 +687,7 @@ func (r *KedaControllerReconciler) installMetricsServer(ctx context.Context, log
 
 		// --- Log output setup ---
 		// validation checks around logOutVolumeClaim and lifetime arguments
-		if err := validateAuditLogVolumeWithArgs(logOutVolumeClaim, instance.Spec.MetricsServer.AuditConfig.AuditLifetime); err != nil {
+		if err := validateAuditLogVolumeWithArgs(logOutVolumeClaim, instance.Spec.MetricsServer.AuditLifetime); err != nil {
 			logger.Error(err, "unable to validate args for Audit logging")
 			return err
 		}
@@ -792,7 +792,7 @@ func (r *KedaControllerReconciler) ensureOpenshiftCABundleConfigMap(ctx context.
 	logger.Info("Ensure ConfigMap for OpenShift CA bundle exists")
 
 	configMap := &corev1.ConfigMap{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: caBundleConfigMapName, Namespace: instance.Namespace}, configMap)
+	err := r.Get(ctx, types.NamespacedName{Name: caBundleConfigMapName, Namespace: instance.Namespace}, configMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			configMap.Name = caBundleConfigMapName
@@ -804,7 +804,7 @@ func (r *KedaControllerReconciler) ensureOpenshiftCABundleConfigMap(ctx context.
 				return err
 			}
 
-			err = r.Client.Create(ctx, configMap)
+			err = r.Create(ctx, configMap)
 			if err != nil {
 				logger.Error(err, "Failed to create new ConfigMap in cluster", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", caBundleConfigMapName)
 				return err
@@ -835,7 +835,7 @@ func (r *KedaControllerReconciler) ensureOpenshiftCABundleConfigMap(ctx context.
 	}
 
 	if configMapUpdate {
-		err = r.Client.Update(ctx, configMap)
+		err = r.Update(ctx, configMap)
 		if err != nil {
 			logger.Error(err, "Failed to update ConfigMap in cluster", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", caBundleConfigMapName)
 			return err
@@ -846,7 +846,7 @@ func (r *KedaControllerReconciler) ensureOpenshiftCABundleConfigMap(ctx context.
 }
 
 func (r *KedaControllerReconciler) ensureMetricsServerAuditLogPolicyConfigMap(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
-	policy := instance.Spec.MetricsServer.AuditConfig.Policy
+	policy := instance.Spec.MetricsServer.Policy
 
 	// create real policy struct from higher level wrapper AuditPolicy exposed to user
 	realPolicy := auditv1.Policy{}
@@ -862,7 +862,7 @@ func (r *KedaControllerReconciler) ensureMetricsServerAuditLogPolicyConfigMap(ct
 	}
 
 	configMap := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: auditlogPolicyConfigMap, Namespace: instance.Namespace}, configMap)
+	err = r.Get(ctx, types.NamespacedName{Name: auditlogPolicyConfigMap, Namespace: instance.Namespace}, configMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// create ConfigMap if not found
@@ -877,7 +877,7 @@ func (r *KedaControllerReconciler) ensureMetricsServerAuditLogPolicyConfigMap(ct
 				return err
 			}
 
-			err = r.Client.Create(ctx, configMap)
+			err = r.Create(ctx, configMap)
 			if err != nil {
 				logger.Error(err, "failed to create new Audit Policy ConfigMap in cluster", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", auditlogPolicyConfigMap)
 				return err
@@ -905,7 +905,7 @@ func (r *KedaControllerReconciler) ensureMetricsServerAuditLogPolicyConfigMap(ct
 	}
 
 	if configMapUpdate {
-		err = r.Client.Update(ctx, configMap)
+		err = r.Update(ctx, configMap)
 		if err != nil {
 			logger.Error(err, "failed to update ConfigMap in cluster", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", auditlogPolicyConfigMap)
 			return err
@@ -1033,14 +1033,14 @@ func auditConfigTransformation(t []mf.Transformer, ac kedav1alpha1.AuditConfig, 
 	if ac.LogFormat != "" {
 		t = append(t, transform.ReplaceAuditConfig(ac.LogFormat, "logformat", scheme, logger))
 	}
-	if ac.AuditLifetime.MaxAge != "" {
-		t = append(t, transform.ReplaceAuditConfig(ac.AuditLifetime.MaxAge, "maxage", scheme, logger))
+	if ac.MaxAge != "" {
+		t = append(t, transform.ReplaceAuditConfig(ac.MaxAge, "maxage", scheme, logger))
 	}
-	if ac.AuditLifetime.MaxBackup != "" {
-		t = append(t, transform.ReplaceAuditConfig(ac.AuditLifetime.MaxBackup, "maxbackup", scheme, logger))
+	if ac.MaxBackup != "" {
+		t = append(t, transform.ReplaceAuditConfig(ac.MaxBackup, "maxbackup", scheme, logger))
 	}
-	if ac.AuditLifetime.MaxSize != "" {
-		t = append(t, transform.ReplaceAuditConfig(ac.AuditLifetime.MaxSize, "maxsize", scheme, logger))
+	if ac.MaxSize != "" {
+		t = append(t, transform.ReplaceAuditConfig(ac.MaxSize, "maxsize", scheme, logger))
 	}
 	return t
 }

--- a/internal/controller/keda/kedacontroller_controller_test.go
+++ b/internal/controller/keda/kedacontroller_controller_test.go
@@ -498,13 +498,13 @@ func changeAttribute(manifest mf.Manifest, attr string, value string, scheme *ru
 			kedaControllerInstance.Spec.AdmissionWebhooks.LogLevel = value
 		// metricsServer audit arguments
 		case "auditLogFormat":
-			kedaControllerInstance.Spec.MetricsServer.AuditConfig.LogFormat = value
+			kedaControllerInstance.Spec.MetricsServer.LogFormat = value
 		case "auditMaxAge":
-			kedaControllerInstance.Spec.MetricsServer.AuditConfig.AuditLifetime.MaxAge = value
+			kedaControllerInstance.Spec.MetricsServer.MaxAge = value
 		case "auditMaxBackup":
-			kedaControllerInstance.Spec.MetricsServer.AuditConfig.AuditLifetime.MaxBackup = value
+			kedaControllerInstance.Spec.MetricsServer.MaxBackup = value
 		case "auditLogMaxSize":
-			kedaControllerInstance.Spec.MetricsServer.AuditConfig.AuditLifetime.MaxSize = value
+			kedaControllerInstance.Spec.MetricsServer.MaxSize = value
 		default:
 			return errors.New("Not a valid attribute")
 		}

--- a/internal/controller/keda/kedacontroller_finalizer.go
+++ b/internal/controller/keda/kedacontroller_finalizer.go
@@ -45,7 +45,7 @@ func (r *KedaControllerReconciler) addFinalizer(ctx context.Context, logger logr
 	// Update CR
 	patch := client.MergeFrom(instance.DeepCopy())
 	instance.SetFinalizers(append(instance.GetFinalizers(), kedaControllerFinalizer))
-	err := r.Client.Patch(ctx, instance, patch)
+	err := r.Patch(ctx, instance, patch)
 	if err != nil {
 		logger.Error(err, "Failed to update KedaController with finalizer")
 		return err

--- a/internal/controller/keda/secret_controller.go
+++ b/internal/controller/keda/secret_controller.go
@@ -88,7 +88,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Fetch the Secret instance
 	instance := &corev1.Secret{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after ctrl req.
@@ -101,7 +101,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	kedaController := &kedav1alpha1.KedaController{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "keda", Namespace: r.secretNamespace}, kedaController)
+	err = r.Get(ctx, types.NamespacedName{Name: "keda", Namespace: r.secretNamespace}, kedaController)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// there isn't any keda KedaController CR created in namespace keda -> do nothing

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -23,10 +23,8 @@ var (
 	logTimeEncodings = []string{"epoch", "millis", "nano", "iso8601", "rfc3339", "rfc3339nano"}
 )
 
-// Prefix represents a command-line argument prefix for container arguments.
 type Prefix string
 
-// Command-line argument prefixes for KEDA container configuration.
 const (
 	LogLevelArg           Prefix = "--zap-log-level="
 	LogEncoderArg         Prefix = "--zap-encoder="
@@ -84,7 +82,6 @@ func ReplaceAllNamespaces(namespace string) mf.Transformer {
 	}
 }
 
-// ReplaceNamespace returns a transformer that changes the namespace of a RoleBinding with the given name.
 func ReplaceNamespace(name string, namespace string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetName() == name {
@@ -105,8 +102,6 @@ func ReplaceNamespace(name string, namespace string, scheme *runtime.Scheme, log
 	}
 }
 
-// ReplaceWatchNamespace returns a transformer that sets the WATCH_NAMESPACE environment variable
-// for the specified container in a Deployment.
 func ReplaceWatchNamespace(watchNamespace string, containerName string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		changed := false
@@ -141,8 +136,6 @@ func ReplaceWatchNamespace(watchNamespace string, containerName string, scheme *
 	}
 }
 
-// RemoveSeccompProfile returns a transformer that removes the SeccompProfile from the SecurityContext
-// of the specified container in a Deployment if it's set to RuntimeDefault.
 func RemoveSeccompProfile(containerName string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		changed := false
@@ -172,26 +165,18 @@ func RemoveSeccompProfile(containerName string, scheme *runtime.Scheme, logger l
 	}
 }
 
-// RemoveSeccompProfileFromKedaOperator returns a transformer that removes the SeccompProfile
-// from the KEDA operator container.
 func RemoveSeccompProfileFromKedaOperator(scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return RemoveSeccompProfile(containerNameKedaOperator, scheme, logger)
 }
 
-// RemoveSeccompProfileFromMetricsServer returns a transformer that removes the SeccompProfile
-// from the KEDA metrics server container.
 func RemoveSeccompProfileFromMetricsServer(scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return RemoveSeccompProfile(containerNameMetricsServer, scheme, logger)
 }
 
-// RemoveSeccompProfileFromAdmissionWebhooks returns a transformer that removes the SeccompProfile
-// from the KEDA admission webhooks container.
 func RemoveSeccompProfileFromAdmissionWebhooks(scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	return RemoveSeccompProfile(containerNameAdmissionWebhooks, scheme, logger)
 }
 
-// EnsureCABundleInjectionForValidatingWebhookConfiguration returns a transformer that adds an annotation
-// to a ValidatingWebhookConfiguration to enable CA bundle injection.
 func EnsureCABundleInjectionForValidatingWebhookConfiguration(annotation string, annotationValue string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "ValidatingWebhookConfiguration" {
@@ -209,8 +194,6 @@ func EnsureCABundleInjectionForValidatingWebhookConfiguration(annotation string,
 	}
 }
 
-// EnsureCABundleInjectionForAPIService returns a transformer that adds an annotation to an APIService
-// to enable CA bundle injection and disables InsecureSkipTLSVerify.
 func EnsureCABundleInjectionForAPIService(annotation string, annotationValue string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "APIService" {
@@ -229,8 +212,6 @@ func EnsureCABundleInjectionForAPIService(annotation string, annotationValue str
 	}
 }
 
-// EnsureCertInjectionForService returns a transformer that adds an annotation to a Service
-// with the specified name to enable certificate injection.
 func EnsureCertInjectionForService(serviceName string, annotation string, annotationValue string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Service" && u.GetName() == serviceName {
@@ -245,14 +226,10 @@ func EnsureCertInjectionForService(serviceName string, annotation string, annota
 	}
 }
 
-// MetricsServerEnsureCertificatesVolume returns a transformer that configures certificate volumes
-// and mounts for the KEDA metrics server container.
 func MetricsServerEnsureCertificatesVolume(configMapName, secretName string, scheme *runtime.Scheme) mf.Transformer {
 	return ensureCertificatesVolumeForDeployment(containerNameMetricsServer, configMapName, secretName, scheme)
 }
 
-// KedaOperatorEnsureCertificatesVolume returns a transformer that configures certificate volumes
-// and mounts for the KEDA operator, using projected volumes from service and gRPC client secrets.
 func KedaOperatorEnsureCertificatesVolume(serviceSecretName string, grpcClientCertsSecretName string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -338,8 +315,6 @@ func KedaOperatorEnsureCertificatesVolume(serviceSecretName string, grpcClientCe
 	}
 }
 
-// AdmissionWebhooksEnsureCertificatesVolume returns a transformer that configures certificate volumes
-// and mounts for the KEDA admission webhooks container using projected volumes.
 func AdmissionWebhooksEnsureCertificatesVolume(configMapName, secretName string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -561,9 +536,8 @@ func ensureCertificatesVolumeForDeployment(containerName, configMapName, secretN
 	}
 }
 
-// EnsureCACertsForOperatorDeployment returns transformers that add ConfigMap volumes for CA certificates.
-// The ConfigMaps are mounted as cabundle0, cabundle1, etc. at /custom/ca0, /custom/ca1, etc.
-// with corresponding container args --ca-dir=/custom/ca0, --ca-dir=/custom/ca1, etc.
+// Add configmap volumes for configMapNames named cabundle0, cabundle1, etc. as /custom/ca0, /custom/ca1, etc. with
+// container args --ca-dir=/custom/ca0, --ca-dir=/custom/ca1, etc.
 func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime.Scheme, logger logr.Logger) []mf.Transformer {
 	var retval []mf.Transformer
 
@@ -652,8 +626,6 @@ func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime
 	return retval
 }
 
-// EnsurePathsToCertsInDeployment returns transformers that set certificate file path arguments
-// for the KEDA metrics server container.
 func EnsurePathsToCertsInDeployment(values []string, prefixes []Prefix, scheme *runtime.Scheme, logger logr.Logger) []mf.Transformer {
 	transforms := []mf.Transformer{}
 	for i := range values {
@@ -662,8 +634,6 @@ func EnsurePathsToCertsInDeployment(values []string, prefixes []Prefix, scheme *
 	return transforms
 }
 
-// EnsureAuditPolicyConfigMapMountsVolume returns a transformer that mounts an audit policy ConfigMap
-// as a volume in the KEDA metrics server container.
 func EnsureAuditPolicyConfigMapMountsVolume(configMapName string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -728,8 +698,6 @@ func EnsureAuditPolicyConfigMapMountsVolume(configMapName string, scheme *runtim
 	}
 }
 
-// ReplaceKedaOperatorLogLevel returns a transformer that sets the log level argument
-// for the KEDA operator container. Valid values are: debug, info, error, or an integer.
 func ReplaceKedaOperatorLogLevel(logLevel string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, level := range logLevels {
@@ -754,8 +722,6 @@ func ReplaceKedaOperatorLogLevel(logLevel string, scheme *runtime.Scheme, logger
 	return replaceContainerArg(logLevel, prefix, containerNameKedaOperator, scheme, logger)
 }
 
-// ReplaceKedaOperatorLogEncoder returns a transformer that sets the log encoder argument
-// for the KEDA operator container. Valid values are: json, console.
 func ReplaceKedaOperatorLogEncoder(logEncoder string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, format := range logEncoders {
@@ -776,8 +742,6 @@ func ReplaceKedaOperatorLogEncoder(logEncoder string, scheme *runtime.Scheme, lo
 	return replaceContainerArg(logEncoder, prefix, containerNameKedaOperator, scheme, logger)
 }
 
-// ReplaceMetricsServerLogLevel returns a transformer that sets the log verbosity level
-// for the KEDA metrics server container. Value must be a positive integer.
 func ReplaceMetricsServerLogLevel(logLevel string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	if _, err := strconv.ParseUint(logLevel, 10, 64); err == nil {
@@ -795,8 +759,6 @@ func ReplaceMetricsServerLogLevel(logLevel string, scheme *runtime.Scheme, logge
 	return replaceContainerArg(logLevel, prefix, containerNameMetricsServer, scheme, logger)
 }
 
-// ReplaceKedaOperatorLogTimeEncoding returns a transformer that sets the log time encoding
-// for the KEDA operator container. Valid values are: epoch, millis, nano, iso8601, rfc3339, rfc3339nano.
 func ReplaceKedaOperatorLogTimeEncoding(logTimeEncoding string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, timeEncoding := range logTimeEncodings {
@@ -817,8 +779,6 @@ func ReplaceKedaOperatorLogTimeEncoding(logTimeEncoding string, scheme *runtime.
 	return replaceContainerArg(logTimeEncoding, prefix, containerNameKedaOperator, scheme, logger)
 }
 
-// ReplaceAdmissionWebhooksLogLevel returns a transformer that sets the log level argument
-// for the KEDA admission webhooks container. Valid values are: debug, info, error, or an integer.
 func ReplaceAdmissionWebhooksLogLevel(logLevel string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, level := range logLevels {
@@ -843,8 +803,6 @@ func ReplaceAdmissionWebhooksLogLevel(logLevel string, scheme *runtime.Scheme, l
 	return replaceContainerArg(logLevel, prefix, containerNameAdmissionWebhooks, scheme, logger)
 }
 
-// ReplaceAdmissionWebhooksLogEncoder returns a transformer that sets the log encoder argument
-// for the KEDA admission webhooks container. Valid values are: json, console.
 func ReplaceAdmissionWebhooksLogEncoder(logEncoder string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, format := range logEncoders {
@@ -865,8 +823,6 @@ func ReplaceAdmissionWebhooksLogEncoder(logEncoder string, scheme *runtime.Schem
 	return replaceContainerArg(logEncoder, prefix, containerNameAdmissionWebhooks, scheme, logger)
 }
 
-// ReplaceAdmissionWebhooksLogTimeEncoding returns a transformer that sets the log time encoding
-// for the KEDA admission webhooks container. Valid values are: epoch, millis, nano, iso8601, rfc3339, rfc3339nano.
 func ReplaceAdmissionWebhooksLogTimeEncoding(logTimeEncoding string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	found := false
 	for _, timeEncoding := range logTimeEncodings {
@@ -887,8 +843,6 @@ func ReplaceAdmissionWebhooksLogTimeEncoding(logTimeEncoding string, scheme *run
 	return replaceContainerArg(logTimeEncoding, prefix, containerNameAdmissionWebhooks, scheme, logger)
 }
 
-// ReplaceArbitraryArg returns a transformer that sets an arbitrary command-line argument
-// for the specified resource container. The resource can be: operator, metricsserver, or admissionwebhooks.
 func ReplaceArbitraryArg(argument string, resource string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	prefix := Prefix("")
 	prefixStr := ""
@@ -925,8 +879,6 @@ func ReplaceArbitraryArg(argument string, resource string, scheme *runtime.Schem
 	}
 }
 
-// SetOperatorCertRotation returns a transformer that enables or disables certificate rotation
-// for the KEDA operator container.
 func SetOperatorCertRotation(enable bool, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	arg := "false"
 	if enable {
@@ -935,8 +887,6 @@ func SetOperatorCertRotation(enable bool, scheme *runtime.Scheme, logger logr.Lo
 	return replaceContainerArg(arg, CertRotation, containerNameKedaOperator, scheme, logger)
 }
 
-// ReplaceAuditConfig returns a transformer that sets audit configuration arguments for the KEDA metrics server.
-// Valid selectors are: policyfile, logformat, logpath, maxage, maxbackup, maxsize.
 func ReplaceAuditConfig(argument string, selector string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
 	var prefix string
 	switch selector {
@@ -1068,8 +1018,6 @@ func replaceContainerArgs(values []string, prefix Prefix, containerName string, 
 	}
 }
 
-// AddServiceAccountAnnotations returns a transformer that adds the specified annotations
-// to ServiceAccount resources.
 func AddServiceAccountAnnotations(annotations map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "ServiceAccount" {
@@ -1086,8 +1034,6 @@ func AddServiceAccountAnnotations(annotations map[string]string, scheme *runtime
 	}
 }
 
-// AddServiceAccountLabels returns a transformer that adds the specified labels
-// to ServiceAccount resources.
 func AddServiceAccountLabels(labels map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "ServiceAccount" {
@@ -1104,8 +1050,6 @@ func AddServiceAccountLabels(labels map[string]string, scheme *runtime.Scheme) m
 	}
 }
 
-// AddPodAnnotations returns a transformer that adds the specified annotations
-// to the Pod template in Deployment resources.
 func AddPodAnnotations(annotations map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1122,8 +1066,6 @@ func AddPodAnnotations(annotations map[string]string, scheme *runtime.Scheme) mf
 	}
 }
 
-// AddPodLabels returns a transformer that adds the specified labels
-// to the Pod template in Deployment resources.
 func AddPodLabels(labels map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1140,8 +1082,6 @@ func AddPodLabels(labels map[string]string, scheme *runtime.Scheme) mf.Transform
 	}
 }
 
-// AddDeploymentAnnotations returns a transformer that adds the specified annotations
-// to Deployment resources.
 func AddDeploymentAnnotations(annotations map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1158,8 +1098,6 @@ func AddDeploymentAnnotations(annotations map[string]string, scheme *runtime.Sch
 	}
 }
 
-// AddDeploymentLabels returns a transformer that adds the specified labels
-// to Deployment resources.
 func AddDeploymentLabels(labels map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1187,8 +1125,6 @@ func updateMap(mapToUpdate map[string]string, newValues map[string]string) map[s
 	return newValues
 }
 
-// ReplaceNodeSelector returns a transformer that sets the node selector
-// for the Pod template in Deployment resources.
 func ReplaceNodeSelector(nodeSelector map[string]string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1204,8 +1140,6 @@ func ReplaceNodeSelector(nodeSelector map[string]string, scheme *runtime.Scheme)
 	}
 }
 
-// ReplaceTolerations returns a transformer that sets the tolerations
-// for the Pod template in Deployment resources.
 func ReplaceTolerations(tolerations []corev1.Toleration, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1221,8 +1155,6 @@ func ReplaceTolerations(tolerations []corev1.Toleration, scheme *runtime.Scheme)
 	}
 }
 
-// ReplaceAffinity returns a transformer that sets the affinity rules
-// for the Pod template in Deployment resources.
 func ReplaceAffinity(affinity *corev1.Affinity, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1238,8 +1170,6 @@ func ReplaceAffinity(affinity *corev1.Affinity, scheme *runtime.Scheme) mf.Trans
 	}
 }
 
-// ReplacePriorityClassName returns a transformer that sets the priority class name
-// for the Pod template in Deployment resources.
 func ReplacePriorityClassName(priorityClassName string, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1255,20 +1185,14 @@ func ReplacePriorityClassName(priorityClassName string, scheme *runtime.Scheme) 
 	}
 }
 
-// ReplaceKedaOperatorResources returns a transformer that sets the resource requirements
-// for the KEDA operator container.
 func ReplaceKedaOperatorResources(resources corev1.ResourceRequirements, scheme *runtime.Scheme) mf.Transformer {
 	return replaceResources(resources, containerNameKedaOperator, scheme)
 }
 
-// ReplaceMetricsServerResources returns a transformer that sets the resource requirements
-// for the KEDA metrics server container.
 func ReplaceMetricsServerResources(resources corev1.ResourceRequirements, scheme *runtime.Scheme) mf.Transformer {
 	return replaceResources(resources, containerNameMetricsServer, scheme)
 }
 
-// ReplaceAdmissionWebhooksResources returns a transformer that sets the resource requirements
-// for the KEDA admission webhooks container.
 func ReplaceAdmissionWebhooksResources(resources corev1.ResourceRequirements, scheme *runtime.Scheme) mf.Transformer {
 	return replaceResources(resources, containerNameAdmissionWebhooks, scheme)
 }
@@ -1294,20 +1218,14 @@ func replaceResources(resources corev1.ResourceRequirements, containerName strin
 	}
 }
 
-// ReplaceMetricsServerImage returns a transformer that sets the container image
-// for the KEDA metrics server.
 func ReplaceMetricsServerImage(image string, scheme *runtime.Scheme) mf.Transformer {
 	return replaceContainerImage(image, containerNameMetricsServer, scheme)
 }
 
-// ReplaceKedaOperatorImage returns a transformer that sets the container image
-// for the KEDA operator.
 func ReplaceKedaOperatorImage(image string, scheme *runtime.Scheme) mf.Transformer {
 	return replaceContainerImage(image, containerNameKedaOperator, scheme)
 }
 
-// ReplaceAdmissionWebhooksImage returns a transformer that sets the container image
-// for the KEDA admission webhooks.
 func ReplaceAdmissionWebhooksImage(image string, scheme *runtime.Scheme) mf.Transformer {
 	return replaceContainerImage(image, containerNameAdmissionWebhooks, scheme)
 }
@@ -1333,8 +1251,6 @@ func replaceContainerImage(image string, containerName string, scheme *runtime.S
 	}
 }
 
-// EnsureAuditLogMount returns a transformer that mounts a PersistentVolumeClaim
-// for audit log output in the KEDA metrics server container.
 func EnsureAuditLogMount(pvc string, path string, scheme *runtime.Scheme) mf.Transformer {
 	const logOutputVolumeName = "audit-log"
 	return func(u *unstructured.Unstructured) error {
@@ -1399,8 +1315,6 @@ func EnsureAuditLogMount(pvc string, path string, scheme *runtime.Scheme) mf.Tra
 	}
 }
 
-// ReplaceDeploymentVolumes returns a transformer that adds or replaces volumes
-// in Deployment resources. Existing volumes with matching names are replaced.
 func ReplaceDeploymentVolumes(desiredVolumes []corev1.Volume, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
@@ -1433,8 +1347,6 @@ func ReplaceDeploymentVolumes(desiredVolumes []corev1.Volume, scheme *runtime.Sc
 	}
 }
 
-// ReplaceDeploymentVolumeMounts returns a transformer that adds or replaces volume mounts
-// in KEDA operand containers. Existing mounts with matching names are replaced.
 func ReplaceDeploymentVolumeMounts(desiredVolumeMounts []corev1.VolumeMount, scheme *runtime.Scheme) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -23,8 +23,10 @@ var (
 	logTimeEncodings = []string{"epoch", "millis", "nano", "iso8601", "rfc3339", "rfc3339nano"}
 )
 
+// Prefix represents a command-line argument prefix for container arguments.
 type Prefix string
 
+// Command-line argument prefixes for KEDA container configuration.
 const (
 	LogLevelArg           Prefix = "--zap-log-level="
 	LogEncoderArg         Prefix = "--zap-encoder="
@@ -559,8 +561,9 @@ func ensureCertificatesVolumeForDeployment(containerName, configMapName, secretN
 	}
 }
 
-// Add configmap volumes for configMapNames named cabundle0, cabundle1, etc. as /custom/ca0, /custom/ca1, etc. with
-// container args --ca-dir=/custom/ca0, --ca-dir=/custom/ca1, etc.
+// EnsureCACertsForOperatorDeployment returns transformers that add ConfigMap volumes for CA certificates.
+// The ConfigMaps are mounted as cabundle0, cabundle1, etc. at /custom/ca0, /custom/ca1, etc.
+// with corresponding container args --ca-dir=/custom/ca0, --ca-dir=/custom/ca1, etc.
 func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime.Scheme, logger logr.Logger) []mf.Transformer {
 	var retval []mf.Transformer
 

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -1074,7 +1074,7 @@ func AddPodLabels(labels map[string]string, scheme *runtime.Scheme) mf.Transform
 				return err
 			}
 
-			deploy.Spec.Template.ObjectMeta.Labels = updateMap(deploy.Spec.Template.ObjectMeta.Labels, labels)
+			deploy.Spec.Template.Labels = updateMap(deploy.Spec.Template.Labels, labels)
 
 			return scheme.Convert(deploy, u, nil)
 		}


### PR DESCRIPTION
Update golangci-lint configuration and CI workflow for v2 compatibility.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


