### PR TITLE
feat(cloud): add GCP WIF credential support for OpenShift

### DIFF
--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -165,8 +165,9 @@ metadata:
     categories: Cloud Provider
     certified: "false"
     containerImage: ghcr.io/kedacore/keda-olm-operator:2.19.0
-    createdAt: "2026-04-22T03:27:54Z"
+    createdAt: "2026-04-24T20:34:44Z"
     description: Operator that provides KEDA, a Kubernetes-based event driver autoscaler
+    features.operators.openshift.io/token-auth-gcp: "true"
     operatorframework.io/suggested-namespace: keda
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -589,6 +590,7 @@ spec:
           - config.openshift.io
           resources:
           - apiservers
+          - infrastructures
           verbs:
           - get
           - list

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -164,6 +164,7 @@ metadata:
     containerImage: ghcr.io/kedacore/keda-olm-operator:2.19.0
     createdAt: "2023-09-11T23:35:30Z"
     description: Operator that provides KEDA, a Kubernetes-based event driver autoscaler
+    features.operators.openshift.io/token-auth-gcp: "true"
     operatorframework.io/suggested-namespace: keda
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - infrastructures
   verbs:
   - get
   - list

--- a/internal/controller/keda/cloud/cloud_suite_test.go
+++ b/internal/controller/keda/cloud/cloud_suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testType string
+)
+
+func TestCloud(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cloud Suite")
+}
+
+func init() {
+	flag.StringVar(&testType, "test.type", "", "type of test: unit / functionality / deployment")
+}

--- a/internal/controller/keda/cloud/cloudcredentials.go
+++ b/internal/controller/keda/cloud/cloudcredentials.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"fmt"
+
+	mf "github.com/manifestival/manifestival"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	BoundSATokenPath   = "/var/run/secrets/openshift/serviceaccount"
+	CloudTokenPath     = BoundSATokenPath + "/token"
+	KedaOperatorSAName = "keda-operator"
+)
+
+// CloudCredentialProvider encapsulates the provider-specific parts of the
+// workload identity workflow.
+type CloudCredentialProvider interface {
+	Name() string
+	Enabled() bool
+
+	// SecretName returns the name for the credential Secret the operator creates.
+	SecretName() string
+
+	// BuildCredentialSecret returns the Secret data (key → value) for the
+	// cloud-specific credential file (e.g. GCP external_account JSON).
+	BuildCredentialSecret() (map[string][]byte, error)
+
+	// Transforms returns the manifestival transforms to wire the credential
+	// Secret and env vars into the keda-operator Deployment.
+	Transforms(ctx context.Context, reader client.Reader, scheme *runtime.Scheme) ([]mf.Transformer, error)
+}
+
+// Providers returns the registered cloud credential providers. The first one
+// whose Enabled() returns true wins.
+func Providers() []CloudCredentialProvider {
+	return []CloudCredentialProvider{
+		// TODO(maxcao13): add more here if we ever support AWS STS or Azure AD Workload Identity.
+		&gcpProvider{},
+	}
+}
+
+// EnsureCredentialSecret creates or updates the cloud credential Secret for
+// the given provider. The Secret is owned by the KedaController CR so that
+// garbage collection handles cleanup automatically.
+func EnsureCredentialSecret(ctx context.Context, c client.Client, p CloudCredentialProvider, namespace string, owner metav1.Object, scheme *runtime.Scheme) (controllerutil.OperationResult, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.SecretName(),
+			Namespace: namespace,
+		},
+	}
+	result, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		secret.Labels = map[string]string{
+			"app.kubernetes.io/name": "keda-operator",
+		}
+		data, buildErr := p.BuildCredentialSecret()
+		if buildErr != nil {
+			return fmt.Errorf("building credential data for %s: %w", p.Name(), buildErr)
+		}
+		secret.Data = data
+		return controllerutil.SetOwnerReference(owner, secret, scheme)
+	})
+	return result, err
+}
+
+// BoundSATokenVolume returns the projected volume that mounts the
+// OpenShift-issued service account token, shared across all providers.
+func BoundSATokenVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "bound-sa-token",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							// TODO: "openshift" matches the allowed-audiences that ccoctl
+							// configures on the GCP WIF OIDC provider. Currently, GCP WIF
+							// is only supported on OpenShift clusters.
+							Audience: "openshift",
+							Path:     "token",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// BoundSATokenVolumeMount returns the volume mount for the bound SA token.
+func BoundSATokenVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "bound-sa-token",
+		MountPath: BoundSATokenPath,
+		ReadOnly:  true,
+	}
+}
+
+// CredentialSecretVolume returns a volume backed by the credential Secret.
+func CredentialSecretVolume(volumeName, secretName string) corev1.Volume {
+	return corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+}

--- a/internal/controller/keda/cloud/cloudcredentials_gcp.go
+++ b/internal/controller/keda/cloud/cloudcredentials_gcp.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	mf "github.com/manifestival/manifestival"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kedacore/keda-olm-operator/internal/controller/keda/transform"
+)
+
+const (
+	gcpSecretName     = "keda-gcp-credentials"
+	gcpSecretKey      = "service_account.json"
+	gcpCredVolumeName = "gcp-credentials"
+	gcpCredMountPath  = "/var/run/secrets/gcp"
+
+	gcpSTSTokenURL              = "https://sts.googleapis.com/v1/token"
+	gcpIAMCredentialsURLPattern = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken"
+	gcpWIFAudiencePattern       = "//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s"
+
+	// envGoogleAppCredentials is used by the Google SDK's Application Default
+	// Credentials (ADC) chain as a fallback to locate a credential file.
+	// We pass this through to the keda-operator Deployment.
+	envGoogleAppCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+
+	// envCloudSDKCoreProject is used by the Google SDK as a fallback for the
+	// GCP project ID when the GCE metadata server is unavailable.
+	// The operator reads this from its own env, falling back to the
+	// OpenShift Infrastructure CR, and passes it through to the
+	// keda-operator Deployment.
+	envCloudSDKCoreProject = "CLOUDSDK_CORE_PROJECT"
+)
+
+type gcpProvider struct{}
+
+func (g *gcpProvider) Name() string { return "GCP WIF" }
+
+// Enabled returns true when the operator pod has either:
+//   - AUDIENCE + SERVICE_ACCOUNT_EMAIL (manual/CLI Subscription patch), or
+//   - PROJECT_NUMBER + POOL_ID + PROVIDER_ID + SERVICE_ACCOUNT_EMAIL (console install)
+func (g *gcpProvider) Enabled() bool {
+	if os.Getenv("SERVICE_ACCOUNT_EMAIL") == "" {
+		return false
+	}
+	return os.Getenv("AUDIENCE") != "" ||
+		(os.Getenv("PROJECT_NUMBER") != "" && os.Getenv("POOL_ID") != "" && os.Getenv("PROVIDER_ID") != "")
+}
+
+func (g *gcpProvider) SecretName() string { return gcpSecretName }
+
+// audience returns the full audience string, constructing it from components
+// if AUDIENCE is not set directly.
+func (g *gcpProvider) audience() string {
+	if aud := os.Getenv("AUDIENCE"); aud != "" {
+		return aud
+	}
+	return fmt.Sprintf(gcpWIFAudiencePattern,
+		os.Getenv("PROJECT_NUMBER"), os.Getenv("POOL_ID"), os.Getenv("PROVIDER_ID"),
+	)
+}
+
+// gcpExternalAccountCredential is the JSON schema for the GCP external_account
+// credential file that the GCP SDK reads for workload identity federation.
+type gcpExternalAccountCredential struct {
+	Type                           string              `json:"type"`
+	Audience                       string              `json:"audience"`
+	SubjectTokenType               string              `json:"subject_token_type"`
+	TokenURL                       string              `json:"token_url"`
+	CredentialSource               gcpCredentialSource `json:"credential_source"`
+	ServiceAccountImpersonationURL string              `json:"service_account_impersonation_url"`
+}
+
+type gcpCredentialSource struct {
+	File   string                  `json:"file"`
+	Format gcpCredentialFileFormat `json:"format"`
+}
+
+type gcpCredentialFileFormat struct {
+	Type string `json:"type"`
+}
+
+func (g *gcpProvider) BuildCredentialSecret() (map[string][]byte, error) {
+	saEmail := os.Getenv("SERVICE_ACCOUNT_EMAIL")
+	cred := gcpExternalAccountCredential{
+		Type:             "external_account",
+		Audience:         g.audience(),
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+		TokenURL:         gcpSTSTokenURL,
+		CredentialSource: gcpCredentialSource{
+			File:   CloudTokenPath,
+			Format: gcpCredentialFileFormat{Type: "text"},
+		},
+		ServiceAccountImpersonationURL: fmt.Sprintf(gcpIAMCredentialsURLPattern, saEmail),
+	}
+	raw, err := json.Marshal(cred)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling GCP credential JSON: %w", err)
+	}
+	return map[string][]byte{gcpSecretKey: raw}, nil
+}
+
+// resolveProjectID returns the GCP project ID, checking CLOUDSDK_CORE_PROJECT
+// first and falling back to the Infrastructure CR if on OpenShift.
+// Returns empty string if neither source provides a project ID.
+func (g *gcpProvider) resolveProjectID(ctx context.Context, reader client.Reader) string {
+	if id := os.Getenv(envCloudSDKCoreProject); id != "" {
+		return id
+	}
+	infra := &configv1.Infrastructure{}
+	if err := reader.Get(ctx, types.NamespacedName{Name: "cluster"}, infra); err != nil {
+		return ""
+	}
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.GCP != nil {
+		return infra.Status.PlatformStatus.GCP.ProjectID
+	}
+	return ""
+}
+
+func (g *gcpProvider) Transforms(ctx context.Context, reader client.Reader, scheme *runtime.Scheme) ([]mf.Transformer, error) {
+	projectID := g.resolveProjectID(ctx, reader)
+
+	envVars := []corev1.EnvVar{
+		{Name: envGoogleAppCredentials, Value: gcpCredMountPath + "/" + gcpSecretKey},
+	}
+	if projectID != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: envCloudSDKCoreProject, Value: projectID})
+	}
+
+	volumes := []corev1.Volume{
+		CredentialSecretVolume(gcpCredVolumeName, gcpSecretName),
+		BoundSATokenVolume(),
+	}
+	mounts := []corev1.VolumeMount{
+		{Name: gcpCredVolumeName, MountPath: gcpCredMountPath, ReadOnly: true},
+		BoundSATokenVolumeMount(),
+	}
+	return []mf.Transformer{
+		transform.ReplaceDeploymentVolumes(volumes, scheme),
+		transform.ReplaceDeploymentVolumeMounts(mounts, scheme),
+		transform.ReplaceContainerEnv(envVars, "keda-operator", scheme),
+	}, nil
+}

--- a/internal/controller/keda/cloud/cloudcredentials_gcp_test.go
+++ b/internal/controller/keda/cloud/cloudcredentials_gcp_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func setGCPEnv(env map[string]string) {
+	for k, v := range env {
+		os.Setenv(k, v)
+	}
+}
+
+func clearGCPEnv() {
+	for _, k := range []string{"SERVICE_ACCOUNT_EMAIL", "AUDIENCE", "PROJECT_NUMBER", "POOL_ID", "PROVIDER_ID", "CLOUDSDK_CORE_PROJECT"} {
+		os.Unsetenv(k)
+	}
+}
+
+var _ = Describe("GCP WIF integration", func() {
+
+	BeforeEach(func() {
+		clearGCPEnv()
+	})
+
+	AfterEach(func() {
+		clearGCPEnv()
+	})
+
+	Context("Enabled()", func() {
+		variants := []struct {
+			name string
+			env  map[string]string
+			want bool
+		}{
+			{
+				name: "no env vars",
+				env:  map[string]string{},
+				want: false,
+			},
+			{
+				name: "SERVICE_ACCOUNT_EMAIL only",
+				env:  map[string]string{"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com"},
+				want: false,
+			},
+			{
+				name: "AUDIENCE + SERVICE_ACCOUNT_EMAIL",
+				env: map[string]string{
+					"AUDIENCE":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
+					"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+				},
+				want: true,
+			},
+			{
+				name: "component env vars (console install)",
+				env: map[string]string{
+					"PROJECT_NUMBER":        "123456",
+					"POOL_ID":               "my-pool",
+					"PROVIDER_ID":           "my-provider",
+					"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+				},
+				want: true,
+			},
+			{
+				name: "partial component env vars missing PROVIDER_ID",
+				env: map[string]string{
+					"PROJECT_NUMBER":        "123456",
+					"POOL_ID":               "my-pool",
+					"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+				},
+				want: false,
+			},
+			{
+				name: "AUDIENCE without SERVICE_ACCOUNT_EMAIL",
+				env: map[string]string{
+					"AUDIENCE": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
+				},
+				want: false,
+			},
+		}
+
+		for _, tt := range variants {
+			It("Should return "+strconv.FormatBool(tt.want)+" when "+tt.name, func() {
+				setGCPEnv(tt.env)
+				p := &gcpProvider{}
+				Expect(p.Enabled()).To(Equal(tt.want))
+			})
+		}
+	})
+
+	Context("audience()", func() {
+		variants := []struct {
+			name string
+			env  map[string]string
+			want string
+		}{
+			{
+				name: "AUDIENCE env var takes precedence",
+				env: map[string]string{
+					"AUDIENCE":       "//iam.googleapis.com/projects/999/locations/global/workloadIdentityPools/p/providers/pr",
+					"PROJECT_NUMBER": "123",
+					"POOL_ID":        "pool",
+					"PROVIDER_ID":    "prov",
+				},
+				want: "//iam.googleapis.com/projects/999/locations/global/workloadIdentityPools/p/providers/pr",
+			},
+			{
+				name: "constructed from components",
+				env: map[string]string{
+					"PROJECT_NUMBER": "123456",
+					"POOL_ID":        "my-pool",
+					"PROVIDER_ID":    "my-provider",
+				},
+				want: "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
+			},
+		}
+
+		for _, tt := range variants {
+			It("Should resolve correctly when "+tt.name, func() {
+				setGCPEnv(tt.env)
+				p := &gcpProvider{}
+				Expect(p.audience()).To(Equal(tt.want))
+			})
+		}
+	})
+
+	Context("BuildCredentialSecret()", func() {
+		It("Should produce valid external_account JSON with AUDIENCE env var", func() {
+			setGCPEnv(map[string]string{
+				"AUDIENCE":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
+				"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+			})
+
+			p := &gcpProvider{}
+			data, err := p.BuildCredentialSecret()
+			Expect(err).NotTo(HaveOccurred())
+
+			raw, ok := data[gcpSecretKey]
+			Expect(ok).To(BeTrue(), "missing key %q in secret data", gcpSecretKey)
+
+			var cred gcpExternalAccountCredential
+			Expect(json.Unmarshal(raw, &cred)).To(Succeed())
+
+			Expect(cred.Type).To(Equal("external_account"))
+			Expect(cred.Audience).To(Equal("//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov"))
+			Expect(cred.TokenURL).To(Equal(gcpSTSTokenURL))
+			Expect(cred.CredentialSource.File).To(Equal(CloudTokenPath))
+
+			wantImpersonation := "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@proj.iam.gserviceaccount.com:generateAccessToken"
+			Expect(cred.ServiceAccountImpersonationURL).To(Equal(wantImpersonation))
+		})
+
+		It("Should use component env vars when AUDIENCE is absent", func() {
+			setGCPEnv(map[string]string{
+				"PROJECT_NUMBER":        "999",
+				"POOL_ID":               "p",
+				"PROVIDER_ID":           "pr",
+				"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+			})
+
+			p := &gcpProvider{}
+			data, err := p.BuildCredentialSecret()
+			Expect(err).NotTo(HaveOccurred())
+
+			var cred gcpExternalAccountCredential
+			Expect(json.Unmarshal(data[gcpSecretKey], &cred)).To(Succeed())
+
+			wantAudience := "//iam.googleapis.com/projects/999/locations/global/workloadIdentityPools/p/providers/pr"
+			Expect(cred.Audience).To(Equal(wantAudience))
+		})
+	})
+
+	Context("SecretName()", func() {
+		It("Should return the expected GCP Secret name", func() {
+			p := &gcpProvider{}
+			Expect(p.SecretName()).To(Equal(gcpSecretName))
+		})
+	})
+
+	Context("resolveProjectID()", func() {
+		It("Should prefer CLOUDSDK_CORE_PROJECT env var over Infrastructure CR", func() {
+			os.Setenv("CLOUDSDK_CORE_PROJECT", "env-project")
+
+			p := &gcpProvider{}
+			id := p.resolveProjectID(context.Background(), fake.NewClientBuilder().Build())
+			Expect(id).To(Equal("env-project"))
+		})
+
+		It("Should fall back to Infrastructure CR when CLOUDSDK_CORE_PROJECT is not set", func() {
+			s := newTestScheme()
+			infra := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						GCP: &configv1.GCPPlatformStatus{ProjectID: "infra-project"},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(infra).WithObjects(infra).Build()
+
+			p := &gcpProvider{}
+			id := p.resolveProjectID(context.Background(), c)
+			Expect(id).To(Equal("infra-project"))
+		})
+
+		It("Should return empty when neither source provides a project ID", func() {
+			p := &gcpProvider{}
+			id := p.resolveProjectID(context.Background(), fake.NewClientBuilder().Build())
+			Expect(id).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/keda/cloud/cloudcredentials_test.go
+++ b/internal/controller/keda/cloud/cloudcredentials_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	Expect(corev1.AddToScheme(s)).To(Succeed())
+	Expect(kedav1alpha1.AddToScheme(s)).To(Succeed())
+	Expect(configv1.Install(s)).To(Succeed())
+	return s
+}
+
+var _ = Describe("Cloud credential provider registry", func() {
+	Context("Providers()", func() {
+		It("Should return at least the GCP credential provider", func() {
+			providers := Providers()
+			Expect(providers).NotTo(BeEmpty())
+			Expect(providers[0].Name()).To(Equal("GCP WIF"))
+		})
+	})
+})
+
+var _ = Describe("Bound SA token helpers", func() {
+	Context("BoundSATokenVolume", func() {
+		It("Should return a projected volume with correct audience and path", func() {
+			vol := BoundSATokenVolume()
+			Expect(vol.Name).To(Equal("bound-sa-token"))
+			Expect(vol.Projected).NotTo(BeNil())
+			Expect(vol.Projected.Sources).To(HaveLen(1))
+
+			sat := vol.Projected.Sources[0].ServiceAccountToken
+			Expect(sat).NotTo(BeNil())
+			Expect(sat.Audience).To(Equal("openshift"))
+			Expect(sat.Path).To(Equal("token"))
+		})
+	})
+
+	Context("BoundSATokenVolumeMount", func() {
+		It("Should return a read-only mount at the bound SA token path", func() {
+			mount := BoundSATokenVolumeMount()
+			Expect(mount.Name).To(Equal("bound-sa-token"))
+			Expect(mount.MountPath).To(Equal(BoundSATokenPath))
+			Expect(mount.ReadOnly).To(BeTrue())
+		})
+	})
+
+	Context("Volume and mount compatibility", func() {
+		It("Should have matching names between volume and mount", func() {
+			vol := BoundSATokenVolume()
+			mount := BoundSATokenVolumeMount()
+			Expect(vol.Name).To(Equal(mount.Name))
+		})
+	})
+})
+
+var _ = Describe("Credential Secret volume helpers", func() {
+	Context("CredentialSecretVolume", func() {
+		It("Should return a Secret-backed volume", func() {
+			vol := CredentialSecretVolume("my-vol", "my-secret")
+			Expect(vol.Name).To(Equal("my-vol"))
+			Expect(vol.Secret).NotTo(BeNil())
+			Expect(vol.Secret.SecretName).To(Equal("my-secret"))
+		})
+	})
+
+	Context("When using GCP credential constants", func() {
+		It("Should produce a volume and mount with matching names", func() {
+			vol := CredentialSecretVolume(gcpCredVolumeName, gcpSecretName)
+			mount := corev1.VolumeMount{
+				Name:      gcpCredVolumeName,
+				MountPath: gcpCredMountPath,
+				ReadOnly:  true,
+			}
+			Expect(vol.Name).To(Equal(mount.Name))
+			Expect(vol.Secret.SecretName).To(Equal(gcpSecretName))
+		})
+	})
+})
+
+var _ = Describe("EnsureCredentialSecret", func() {
+	var (
+		scheme *runtime.Scheme
+		owner  *kedav1alpha1.KedaController
+		p      *gcpProvider
+	)
+
+	BeforeEach(func() {
+		scheme = newTestScheme()
+		owner = &kedav1alpha1.KedaController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "keda",
+				Namespace: "keda",
+				UID:       types.UID("test-uid"),
+			},
+		}
+		p = &gcpProvider{}
+	})
+
+	Context("When the Secret does not exist", func() {
+		BeforeEach(func() {
+			setGCPEnv(map[string]string{
+				"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+				"AUDIENCE":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
+			})
+		})
+
+		It("Should create the Secret with correct labels, owner reference, and credential data", func() {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			result, err := EnsureCredentialSecret(context.Background(), c, p, "keda", owner, scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerutil.OperationResultCreated))
+
+			secret := &corev1.Secret{}
+			Expect(c.Get(context.Background(), types.NamespacedName{Name: gcpSecretName, Namespace: "keda"}, secret)).To(Succeed())
+
+			Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keda-operator"))
+
+			Expect(secret.OwnerReferences).To(HaveLen(1))
+			Expect(secret.OwnerReferences[0].UID).To(Equal(owner.UID))
+
+			raw, ok := secret.Data[gcpSecretKey]
+			Expect(ok).To(BeTrue(), "expected key %q in Secret data", gcpSecretKey)
+
+			var cred gcpExternalAccountCredential
+			Expect(json.Unmarshal(raw, &cred)).To(Succeed())
+			Expect(cred.Type).To(Equal("external_account"))
+			Expect(cred.Audience).To(ContainSubstring("workloadIdentityPools"))
+		})
+	})
+
+	Context("When the Secret already exists with stale data", func() {
+		BeforeEach(func() {
+			setGCPEnv(map[string]string{
+				"SERVICE_ACCOUNT_EMAIL": "sa@proj.iam.gserviceaccount.com",
+				"AUDIENCE":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov",
+			})
+		})
+
+		It("Should update the Secret and replace the stale data", func() {
+			existing := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gcpSecretName,
+					Namespace: "keda",
+				},
+				Data: map[string][]byte{"stale": []byte("data")},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+			result, err := EnsureCredentialSecret(context.Background(), c, p, "keda", owner, scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerutil.OperationResultUpdated))
+
+			secret := &corev1.Secret{}
+			Expect(c.Get(context.Background(), types.NamespacedName{Name: gcpSecretName, Namespace: "keda"}, secret)).To(Succeed())
+
+			Expect(secret.Data).NotTo(HaveKey("stale"))
+			Expect(secret.Data).To(HaveKey(gcpSecretKey))
+		})
+	})
+})

--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+	"github.com/kedacore/keda-olm-operator/internal/controller/keda/cloud"
 	"github.com/kedacore/keda-olm-operator/internal/controller/keda/transform"
 	"github.com/kedacore/keda-olm-operator/internal/controller/keda/util"
 	"github.com/kedacore/keda-olm-operator/resources"
@@ -325,6 +326,7 @@ func (r *KedaControllerReconciler) tlsEnvVarTransforms(ctx context.Context, logg
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs="*"
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 
 // Reconcile reads that state of the cluster for a KedaController object and makes changes based on the state read
 // and what is in the KedaController.Spec
@@ -386,6 +388,10 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	status := instance.Status.DeepCopy()
+
+	if err := r.ensureCloudCredentialSecret(ctx, logger, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if err := r.installGeneralResources(ctx, logger, instance); err != nil {
 		status.MarkInstallFailed("Not able to create ServiceAccount")
@@ -580,13 +586,45 @@ func (r *KedaControllerReconciler) installGeneralResources(ctx context.Context, 
 	}
 
 	if err := toApply.Apply(); err != nil {
-		logger.Error(err, "Unable to install ServiceAccount and NetworkPolicies")
+		logger.Error(err, "Unable to install ServiceAccount and NetworkPoliciess")
 		return err
 	}
 
 	return nil
 }
 
+// cloudCredentialTransforms returns the manifestival transforms that wire
+// cloud credential volumes, mounts, and env vars into the keda-operator
+// Deployment when a workload identity strategy is active.
+func (r *KedaControllerReconciler) cloudCredentialTransforms(ctx context.Context) ([]mf.Transformer, error) {
+	for _, p := range cloud.Providers() {
+		if p.Enabled() {
+			return p.Transforms(ctx, r.Client, r.Scheme)
+		}
+	}
+	return nil, nil
+}
+
+// ensureCloudCredentialSecret creates or updates the workload identity
+// credential Secret (e.g. GCP WIF) when a cloud credential provider is
+// enabled (through environment variables to the olm operator).
+func (r *KedaControllerReconciler) ensureCloudCredentialSecret(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
+	for _, p := range cloud.Providers() {
+		if p.Enabled() {
+			result, err := cloud.EnsureCredentialSecret(ctx, r.Client, p, instance.Namespace, instance, r.Scheme)
+			if err != nil {
+				return err
+			}
+			if result == controllerutil.OperationResultCreated {
+				logger.Info("Created cloud credential Secret", "provider", p.Name())
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+//nolint:gocyclo // upstream complexity is already at the threshold; our cloud credential block adds one branch
 func (r *KedaControllerReconciler) installController(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
 	logger.Info("Reconciling KEDA Controller deployment")
 	transforms := []mf.Transformer{
@@ -701,6 +739,12 @@ func (r *KedaControllerReconciler) installController(ctx context.Context, logger
 		i := i
 		transforms = append(transforms, transform.ReplaceArbitraryArg(instance.Spec.Operator.Args[i], "operator", r.Scheme, logger))
 	}
+
+	cloudTransforms, err := r.cloudCredentialTransforms(ctx)
+	if err != nil {
+		return err
+	}
+	transforms = append(transforms, cloudTransforms...)
 
 	manifest, err := r.resourcesController.Transform(transforms...)
 	if err != nil {

--- a/internal/controller/keda/kedacontroller_controller_test.go
+++ b/internal/controller/keda/kedacontroller_controller_test.go
@@ -18,8 +18,10 @@ package keda
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -28,6 +30,8 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -361,6 +365,208 @@ var _ = Describe("Testing functionality", func() {
 				})
 			}
 		})
+	})
+
+	var _ = Describe("GCP WIF integration", func() {
+		var (
+			ctx                  = context.Background()
+			deploymentName       = "keda-operator"
+			containerName        = "keda-operator"
+			eventuallyTimeout    = time.Second * 30
+			consistentlyTimeout  = time.Second * 5
+			interval             = time.Millisecond * 250
+			namespace            = "keda"
+			kedaManifestFilepath = "../../../config/samples/keda_v1alpha1_kedacontroller.yaml"
+		)
+
+		variants := []struct {
+			name string
+			env  map[string]string
+		}{
+			{
+				name: "Subscription patch (AUDIENCE)",
+				env: map[string]string{
+					"SERVICE_ACCOUNT_EMAIL": "sa@test-project.iam.gserviceaccount.com",
+					"AUDIENCE":              "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+					"CLOUDSDK_CORE_PROJECT": "test-project-id",
+				},
+			},
+			{
+				name: "Console install (component vars)",
+				env: map[string]string{
+					"SERVICE_ACCOUNT_EMAIL": "sa@test-project.iam.gserviceaccount.com",
+					"PROJECT_NUMBER":        "123456",
+					"POOL_ID":               "test-pool",
+					"PROVIDER_ID":           "test-provider",
+					"CLOUDSDK_CORE_PROJECT": "test-project-id",
+				},
+			},
+		}
+
+		for _, v := range variants {
+			Context("When configured via "+v.name, func() {
+				BeforeEach(func() {
+					By("Setting GCP WIF environment variables")
+					for k, val := range v.env {
+						os.Setenv(k, val)
+					}
+
+					By("Applying the KedaController manifest to trigger reconciliation")
+					manifest, err := createManifest(kedaManifestFilepath, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(manifest.Apply()).Should(Succeed())
+				})
+
+				AfterEach(func() {
+					By("Cleaning up GCP WIF environment variables")
+					for k := range v.env {
+						os.Unsetenv(k)
+					}
+
+					By("Cleaning up credential Secret and KedaController CR")
+					_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "keda-gcp-credentials", Namespace: namespace}})
+					kc := &kedav1alpha1.KedaController{ObjectMeta: metav1.ObjectMeta{Name: "keda", Namespace: namespace}}
+					_ = k8sClient.Delete(ctx, kc)
+
+					By("Waiting for KedaController CR to be fully removed")
+					Eventually(func() bool {
+						err := k8sClient.Get(ctx, types.NamespacedName{Name: "keda", Namespace: namespace}, kc)
+						return apierrors.IsNotFound(err)
+					}, eventuallyTimeout, interval).Should(BeTrue())
+				})
+
+				It("Should create the GCP credential Secret with valid external_account data", func() {
+					By("Waiting for the credential Secret to be created by the reconciler")
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{
+							Name:      "keda-gcp-credentials",
+							Namespace: namespace,
+						}, secret)
+					}, eventuallyTimeout, interval).Should(Succeed())
+
+					Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keda-operator"))
+					Expect(secret.OwnerReferences).NotTo(BeEmpty())
+					Expect(secret.Data).To(HaveKey("service_account.json"))
+
+					var cred map[string]interface{}
+					Expect(json.Unmarshal(secret.Data["service_account.json"], &cred)).To(Succeed())
+					Expect(cred["type"]).To(Equal("external_account"))
+					Expect(cred["audience"]).To(ContainSubstring("workloadIdentityPools"))
+				})
+
+				It("Should wire GCP volumes, mounts, and env vars into the keda-operator Deployment", func() {
+					By("Waiting for the keda-operator Deployment to have the gcp-credentials volume")
+					Eventually(func() error {
+						dep := &appsv1.Deployment{}
+						if err := k8sClient.Get(ctx, types.NamespacedName{
+							Name:      deploymentName,
+							Namespace: namespace,
+						}, dep); err != nil {
+							return err
+						}
+						for _, vol := range dep.Spec.Template.Spec.Volumes {
+							if vol.Name == "gcp-credentials" {
+								return nil
+							}
+						}
+						return fmt.Errorf("gcp-credentials volume not found yet")
+					}, eventuallyTimeout, interval).Should(Succeed())
+
+					dep := &appsv1.Deployment{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{
+						Name:      deploymentName,
+						Namespace: namespace,
+					}, dep)).To(Succeed())
+
+					By("Verifying the Deployment has the expected volumes")
+					volumeNames := []string{}
+					for _, vol := range dep.Spec.Template.Spec.Volumes {
+						volumeNames = append(volumeNames, vol.Name)
+					}
+					Expect(volumeNames).To(ContainElement("gcp-credentials"))
+					Expect(volumeNames).To(ContainElement("bound-sa-token"))
+
+					By("Verifying the keda-operator container has the expected env vars")
+					var kedaContainer *corev1.Container
+					for i := range dep.Spec.Template.Spec.Containers {
+						if dep.Spec.Template.Spec.Containers[i].Name == containerName {
+							kedaContainer = &dep.Spec.Template.Spec.Containers[i]
+							break
+						}
+					}
+					Expect(kedaContainer).NotTo(BeNil(), "keda-operator container not found")
+
+					envNames := []string{}
+					for _, env := range kedaContainer.Env {
+						envNames = append(envNames, env.Name)
+					}
+					Expect(envNames).To(ContainElement("GOOGLE_APPLICATION_CREDENTIALS"))
+					Expect(envNames).To(ContainElement("CLOUDSDK_CORE_PROJECT"))
+
+					By("Verifying the keda-operator container has the expected volume mounts")
+					mountNames := []string{}
+					for _, mount := range kedaContainer.VolumeMounts {
+						mountNames = append(mountNames, mount.Name)
+					}
+					Expect(mountNames).To(ContainElement("gcp-credentials"))
+					Expect(mountNames).To(ContainElement("bound-sa-token"))
+				})
+			})
+		}
+
+		skipVariants := []struct {
+			name string
+			env  map[string]string
+		}{
+			{
+				name: "no WIF env vars",
+				env:  map[string]string{},
+			},
+			{
+				name: "partial WIF env vars (SERVICE_ACCOUNT_EMAIL only)",
+				env:  map[string]string{"SERVICE_ACCOUNT_EMAIL": "sa@test-project.iam.gserviceaccount.com"},
+			},
+		}
+
+		for _, sv := range skipVariants {
+			Context("When "+sv.name+" are set", func() {
+				BeforeEach(func() {
+					for k, val := range sv.env {
+						os.Setenv(k, val)
+					}
+
+					By("Applying the KedaController manifest to trigger reconciliation")
+					manifest, err := createManifest(kedaManifestFilepath, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(manifest.Apply()).Should(Succeed())
+				})
+
+				AfterEach(func() {
+					for k := range sv.env {
+						os.Unsetenv(k)
+					}
+					_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "keda-gcp-credentials", Namespace: namespace}})
+					kc := &kedav1alpha1.KedaController{ObjectMeta: metav1.ObjectMeta{Name: "keda", Namespace: namespace}}
+					_ = k8sClient.Delete(ctx, kc)
+
+					Eventually(func() bool {
+						err := k8sClient.Get(ctx, types.NamespacedName{Name: "keda", Namespace: namespace}, kc)
+						return apierrors.IsNotFound(err)
+					}, eventuallyTimeout, interval).Should(BeTrue())
+				})
+
+				It("Should not create a GCP credential Secret", func() {
+					Consistently(func() error {
+						secret := &corev1.Secret{}
+						return k8sClient.Get(ctx, types.NamespacedName{
+							Name:      "keda-gcp-credentials",
+							Namespace: namespace,
+						}, secret)
+					}, consistentlyTimeout, interval).ShouldNot(Succeed())
+				})
+			})
+		}
 	})
 })
 

--- a/internal/controller/keda/suite_test.go
+++ b/internal/controller/keda/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -145,6 +146,9 @@ func setupEnv(testEnv *envtest.Environment, scheme *runtime.Scheme) (manager ctr
 
 	err = kedav1alpha1.AddToScheme(scheme)
 	if err != nil {
+		return
+	}
+	if err = apiregistrationv1.AddToScheme(scheme); err != nil {
 		return
 	}
 

--- a/internal/controller/keda/transform/transform_test.go
+++ b/internal/controller/keda/transform/transform_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/kedacore/keda-olm-operator/internal/controller/keda/transform"
 )
 
+const testTypeUnit = "unit"
+
 var _ = Describe("Transforming all resource namespaces", func() {
 	var _ = Describe("Changing namespace", func() {
 		Context("When transforming a ServiceAccount", func() {
@@ -85,7 +87,7 @@ spec:
   versionPriority: 100
 `
 			It("Should be able to change the namespace in the object's spec.service.namespace field", func() {
-				if testType != "unit" {
+				if testType != testTypeUnit {
 					Skip("test.type isn't 'unit'")
 				}
 
@@ -113,7 +115,7 @@ spec:
 var _ = Describe("Transforming deployment spec for volumes", func() {
 	var _ = Describe("Overriding volumes", func() {
 		BeforeEach(func() {
-			if testType != "unit" {
+			if testType != testTypeUnit {
 				Skip("test.type isn't 'unit'")
 			}
 		})
@@ -506,6 +508,137 @@ spec:
 			}
 			Expect(peers).To(ContainElement(structuredToMap(desiredPeer)))
 			Expect(err).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Transforming deployment spec for env vars", func() {
+	var _ = Describe("Overriding container env vars", func() {
+		BeforeEach(func() {
+			if testType != testTypeUnit {
+				Skip("test.type isn't 'unit'")
+			}
+		})
+		Context("When transforming a Deployment", func() {
+			scheme := runtime.NewScheme()
+			_ = appsv1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			yamlData := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-keda-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda
+  template:
+    metadata:
+      labels:
+        app: keda
+    spec:
+      containers:
+        - name: keda-operator
+          image: keda:latest
+          env:
+            - name: EXISTING_VAR
+              value: original
+        - name: sidecar
+          image: sidecar:latest`
+
+			It("Should add env vars to the targeted container", func() {
+				manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+				Expect(err).To(BeNil())
+
+				envVars := []corev1.EnvVar{
+					{Name: "MY_VAR", Value: "/some/path"},
+				}
+				transforms := []mf.Transformer{transform.ReplaceContainerEnv(envVars, "keda-operator", scheme)}
+				newManifest, err := manifest.Transform(transforms...)
+				Expect(err).To(BeNil())
+
+				r := newManifest.Resources()
+				Expect(len(r)).To(Equal(1))
+
+				containers, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "containers")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				envs, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "env")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				Expect(envs).To(ContainElement(structuredToMap(corev1.EnvVar{Name: "MY_VAR", Value: "/some/path"})))
+				Expect(envs).To(ContainElement(structuredToMap(corev1.EnvVar{Name: "EXISTING_VAR", Value: "original"})))
+			})
+
+			It("Should replace an existing env var by name", func() {
+				manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+				Expect(err).To(BeNil())
+
+				envVars := []corev1.EnvVar{
+					{Name: "EXISTING_VAR", Value: "replaced"},
+				}
+				transforms := []mf.Transformer{transform.ReplaceContainerEnv(envVars, "keda-operator", scheme)}
+				newManifest, err := manifest.Transform(transforms...)
+				Expect(err).To(BeNil())
+
+				r := newManifest.Resources()
+				containers, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "containers")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				envs, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "env")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				Expect(envs).To(ContainElement(structuredToMap(corev1.EnvVar{Name: "EXISTING_VAR", Value: "replaced"})))
+				Expect(envs).NotTo(ContainElement(structuredToMap(corev1.EnvVar{Name: "EXISTING_VAR", Value: "original"})))
+			})
+
+			It("Should not modify containers that don't match the target name", func() {
+				manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+				Expect(err).To(BeNil())
+
+				envVars := []corev1.EnvVar{
+					{Name: "INJECTED", Value: "yes"},
+				}
+				transforms := []mf.Transformer{transform.ReplaceContainerEnv(envVars, "keda-operator", scheme)}
+				newManifest, err := manifest.Transform(transforms...)
+				Expect(err).To(BeNil())
+
+				r := newManifest.Resources()
+				containers, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "containers")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				// Sidecar (index 1) should have no env
+				sidecarEnvs, found, _ := unstructured.NestedSlice(structuredToMap(containers[1]), "env")
+				Expect(found).To(BeFalse(), "sidecar should not have env vars injected")
+				Expect(sidecarEnvs).To(BeNil())
+			})
+
+			It("Should be a no-op for non-Deployment resources", func() {
+				saYaml := `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-sa
+  namespace: keda`
+				manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(saYaml)))
+				Expect(err).To(BeNil())
+
+				envVars := []corev1.EnvVar{{Name: "FOO", Value: "bar"}}
+				transforms := []mf.Transformer{transform.ReplaceContainerEnv(envVars, "keda-operator", scheme)}
+				newManifest, err := manifest.Transform(transforms...)
+				Expect(err).To(BeNil())
+
+				r := newManifest.Resources()
+				Expect(len(r)).To(Equal(1))
+				Expect(r[0].GetKind()).To(Equal("ServiceAccount"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**AI Summary:**

Introduce a cloud credential provider framework that creates and manages GCP WIF secrets. The operator builds the `external_account` credential JSON, creates the Secret via `CreateOrUpdate` with owner references, and wires volumes/mounts/env vars into the `keda-operator` Deployment.

- New cloud package with provider interface and GCP WIF implementation
- Platform-agnostic enablement gated on env vars, with Infrastructure CR fallback for project ID on OpenShift
- Transform helpers for injecting volumes, mounts, and env vars
- Unit and envtest integration tests covering both Subscription-patch and console-install env var configurations, plus negative cases
- RBAC updates for Secret management

Made-with: Cursor

**My summary**:

Allows the `keda-olm-operator` to be enabled with gcp wif integration for Red Hat OpenShift (currently not supported for general case Kubernetes with OLM). I tried to keep the code structure as generic for identity provider workflows, in the case we need to support Azure or AWS in the future.

A [user story]/[testing workflow] is as follows:

User wants to scale their pods on OCP with KEDA OLM Operator based on their managed Prometheus instance in their GCP project: e.g. https://keda.sh/docs/2.19/scalers/prometheus/#google-managed-service-for-prometheus

1. User installs openshift cluster on GCP using the [OCP installer with Manual credential mode to enable GCP WIF](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/installing_on_google_cloud/index#installing-gcp-with-short-term-creds_installing-gcp-customizations)
2. User creates a GCP IAM service account with proper permissions to retrieve metrics for the the Prometheus Scaler and assigns the monitoring role as detailed docs above: https://keda.sh/docs/2.19/scalers/prometheus/#google-managed-service-for-prometheus
3. User installs the `keda-olm-operator` through OperatorHub, and fills in the console parameters accordingly (GCP project number, pool ID, SA email, provider id) (they can also edit their `Subscription` object without the console path with `AUDIENCE` + `SERVICE_ACCOUNT_EMAIL`):
<img width="2761" height="968" alt="image" src="https://github.com/user-attachments/assets/9263bcd3-e7d8-4989-a04c-a74571aaf80a" />

4. The parameters get translated as environment variables passed to the olm operator pod, and the olm operator code then builds an `external_account` json embedded secret with the `WIF audience URI`, `STS token URL`, `SA impersonation URL`, and the path to the projected token file.
5. We also pass in `CLOUDSDK_CORE_PROJECT` if it's set from the `Subscription` object to pass to the `keda-operator`. The `keda-operator` code uses this environment variable as the default GCP project ID to use when calling SDK code. If the env var is not set, it falls back to checking the project ID on the infrastructure object (only on OpenShift). 
6. The olm operator then mounts the secret into the `keda-operator` pod, and passes in `GOOGLE_APPLICATION_CREDENTIALS` pointing to that mounted credential so that the `keda-operator` can now obtain a short-term access token from the `STS token url` to impersonate the authorized service account from earlier. `keda-operator` can now query your GCP project for anything it needs now (and can access, in this case, it's the managed prometheus instance in GCP which only needs the [monitoring.viewer](https://cloud.google.com/iam/docs/understanding-roles#monitoring.viewer) role) that it has the temporary access token.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
