### PR TITLE
refactor: use embed.FS for resource manifests instead of runtime.Caller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION}
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/resources/keda.yaml /workspace/resources/keda.yaml
-COPY --from=builder /workspace/resources/keda-olm-operator.yaml /workspace/resources/keda-olm-operator.yaml
-COPY --from=builder /workspace/resources/keda-http-addon.yaml /workspace/resources/keda-http-addon.yaml
 COPY --from=builder /workspace/bin/manager .
 # 65532 is numeric for nonroot
 USER 65532:65532

--- a/resources/resources_handler.go
+++ b/resources/resources_handler.go
@@ -1,31 +1,39 @@
 package resources
 
 import (
-	"path/filepath"
-	"runtime"
+	"bytes"
+	"embed"
 
 	mf "github.com/manifestival/manifestival"
 )
 
-const resourcesPath = "keda.yaml"
-const olmResourcesPath = "keda-olm-operator.yaml"
-const httpAddonResourcesPath = "keda-http-addon.yaml"
-const LastConfigID = "olm-operator.keda.sh/last-applied-configuration"
+//go:embed keda.yaml keda-olm-operator.yaml keda-http-addon.yaml
+var content embed.FS
+
+const (
+	resourcesPath          = "keda.yaml"
+	olmResourcesPath       = "keda-olm-operator.yaml"
+	httpAddonResourcesPath = "keda-http-addon.yaml"
+	LastConfigID           = "olm-operator.keda.sh/last-applied-configuration"
+)
 
 func GetResourcesManifest() (mf.Manifest, error) {
-	_, path, _, _ := runtime.Caller(0)
-	fullPath := filepath.Join(filepath.Dir(path), resourcesPath)
-	olmFullPath := filepath.Join(filepath.Dir(path), olmResourcesPath)
-	kedamf, err := mf.NewManifest(fullPath, mf.UseLastAppliedConfigAnnotation(LastConfigID))
+	kedamf, err := manifestFromEmbed(resourcesPath)
 	if err != nil {
 		return kedamf, err
 	}
-	operatormf, err := mf.NewManifest(olmFullPath, mf.UseLastAppliedConfigAnnotation(LastConfigID))
+	operatormf, err := manifestFromEmbed(olmResourcesPath)
 	return kedamf.Append(operatormf), err
 }
 
 func GetHTTPAddonResourcesManifest() (mf.Manifest, error) {
-	_, path, _, _ := runtime.Caller(0)
-	fullPath := filepath.Join(filepath.Dir(path), httpAddonResourcesPath)
-	return mf.NewManifest(fullPath, mf.UseLastAppliedConfigAnnotation(LastConfigID))
+	return manifestFromEmbed(httpAddonResourcesPath)
+}
+
+func manifestFromEmbed(name string) (mf.Manifest, error) {
+	data, err := content.ReadFile(name)
+	if err != nil {
+		return mf.Manifest{}, err
+	}
+	return mf.ManifestFrom(mf.Reader(bytes.NewReader(data)), mf.UseLastAppliedConfigAnnotation(LastConfigID))
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Embeds keda.yaml, keda-olm-operator.yaml, and keda-http-addon.yaml into the binary at compile time, eliminating the brittle runtime.Caller(0) filesystem path resolution. This makes the binary fully self-contained and removes the need to copy YAML files into the runtime container image.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
