### PR TITLE
refactor: replace hand-rolled finalizer helpers with controllerutil

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -345,7 +345,7 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if instance.GetDeletionTimestamp() != nil {
-		if contains(instance.GetFinalizers(), kedaControllerFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, kedaControllerFinalizer) {
 			// Run finalization logic for kedaControllerFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
@@ -355,9 +355,8 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			// Remove kedaControllerFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
 			patch := client.MergeFrom(instance.DeepCopy())
-			instance.SetFinalizers(remove(instance.GetFinalizers(), kedaControllerFinalizer))
-			err := r.Patch(ctx, instance, patch)
-			if err != nil {
+			controllerutil.RemoveFinalizer(instance, kedaControllerFinalizer)
+			if err := r.Patch(ctx, instance, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -365,7 +364,7 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Add finalizer for this CR
-	if !contains(instance.GetFinalizers(), kedaControllerFinalizer) {
+	if !controllerutil.ContainsFinalizer(instance, kedaControllerFinalizer) {
 		if err := r.addFinalizer(ctx, logger, instance); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/keda/kedacontroller_finalizer.go
+++ b/internal/controller/keda/kedacontroller_finalizer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
 )
@@ -33,12 +34,6 @@ func (r *KedaControllerReconciler) finalizeKedaController(logger logr.Logger) er
 		return err
 	}
 
-	// DO NOT manage deletion of namespace at the moment (as it was created manually)
-	// if err := r.removeNamespace(installationNamespace); err != nil {
-	// 	logger.Info("error finalized KedaController namespace", "error", err)
-	// 	return err
-	// }
-
 	logger.Info("Successfully finalized KedaController")
 	return nil
 }
@@ -47,31 +42,11 @@ func (r *KedaControllerReconciler) finalizeKedaController(logger logr.Logger) er
 func (r *KedaControllerReconciler) addFinalizer(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
 	logger.Info("Adding Finalizer for the KedaController")
 
-	// Update CR
 	patch := client.MergeFrom(instance.DeepCopy())
-	instance.SetFinalizers(append(instance.GetFinalizers(), kedaControllerFinalizer))
-	err := r.Patch(ctx, instance, patch)
-	if err != nil {
+	controllerutil.AddFinalizer(instance, kedaControllerFinalizer)
+	if err := r.Patch(ctx, instance, patch); err != nil {
 		logger.Error(err, "Failed to update KedaController with finalizer")
 		return err
 	}
 	return nil
-}
-
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-func remove(list []string, s string) []string {
-	for i, v := range list {
-		if v == s {
-			list = append(list[:i], list[i+1:]...)
-		}
-	}
-	return list
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Use controllerutil.ContainsFinalizer, AddFinalizer, and RemoveFinalizer from controller-runtime instead of custom contains/remove slice helpers. Also removes the stale commented-out namespace deletion code.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
