### PR TITLE
chore: replace deprecated kustomize fields with modern equivalents

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -13,15 +13,15 @@ resources:
 - bases/http.keda.sh_interceptorroutes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_kedacontrollers.yaml
+#- path: patches/webhook_in_kedacontrollers.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_kedacontrollers.yaml
+#- path: patches/cainjection_in_kedacontrollers.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,10 @@ namespace: keda
 # namePrefix: keda-olm-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- pairs:
+#    someName: someValue
+#  includeSelectors: true
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
@@ -42,6 +44,8 @@ resources:
 - ../general
 - ../rbac
 - ../manager
-commonLabels:
-  app.kubernetes.io/part-of: keda-olm-operator
-  app.kubernetes.io/version: main
+labels:
+- pairs:
+    app.kubernetes.io/part-of: keda-olm-operator
+    app.kubernetes.io/version: main
+  includeSelectors: true

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app.kubernetes.io/name: keda-operator
-  app.kubernetes.io/part-of: keda-operator
+labels:
+- pairs:
+    app.kubernetes.io/name: keda-operator
+    app.kubernetes.io/part-of: keda-operator
+  includeSelectors: true
 
 resources:
 - role.yaml

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-# +kubebuilder:scaffold:patchesJson6902
+# +kubebuilder:scaffold:patches


### PR DESCRIPTION


<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Migrate commonLabels to labels, patchesStrategicMerge and patchesJson6902 to the unified patches field to eliminate deprecation warnings from newer kustomize versions.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
