### PR TITLE
ci: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -16,18 +16,18 @@ jobs:
     container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Go modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /go/pkg
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -65,13 +65,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -130,18 +130,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Go modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /go/pkg
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -60,7 +60,7 @@ jobs:
         run: make sign-images
 
   deploy-test:
-    needs: Build
+    needs: build
     name: Deploy-test
     runs-on: ubuntu-latest
     steps:
@@ -125,7 +125,7 @@ jobs:
         run: make test-deployment
 
   deploy:
-    needs: Deploy-test
+    needs: deploy-test
     name: Deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -28,9 +28,9 @@ jobs:
     name: Static Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: golangci-lint
@@ -50,18 +50,18 @@ jobs:
     container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Go modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /go/pkg
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
     container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/version-diff.yml
+++ b/.github/workflows/version-diff.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
       old_files: ${{ steps.setup-id.outputs.old_files }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout Pull Request
         env:


### PR DESCRIPTION
Bump GitHub Actions to versions that run on Node.js 24, resolving
the deprecation warnings for Node.js 20 runners:

- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6
- `actions/setup-python` v5 → v6
- `actions/cache` v4 → v5

Also fix incorrect `needs` references in `main-build.yml` that used
job display names (`Build`, `Deploy-test`) instead of job IDs
(`build`, `deploy-test`).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)