### PR TITLE
fix!(http-add-on): normalize HTTP Add-on labels

### DIFF
--- a/hack/http-add-on-relprep.sh
+++ b/hack/http-add-on-relprep.sh
@@ -33,8 +33,37 @@ fi
 
 # Post-process the manifest to fix labels
 echo "Fixing labels in manifest..."
-sed -i '/app\.kubernetes\.io\/managed-by: kustomize/d' "$tmpfile"
-sed -i "s/app\.kubernetes\.io\/version: HEAD/app.kubernetes.io\/version: ${ver}/" "$tmpfile"
+python3 -c "
+import re, sys
+ver, path = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    content = f.read()
+content = content.replace('app.kubernetes.io/managed-by: kustomize\n', '')
+content = content.replace('app.kubernetes.io/version: HEAD', 'app.kubernetes.io/version: ' + ver)
+
+# Fix deployment selector labels: upstream misuses app.kubernetes.io/instance as a
+# component differentiator and sets component to the non-differentiating 'add-on'.
+# See https://github.com/kedacore/http-add-on/issues/1462
+# TODO: remove after release of HTTP Addon 1.0.0
+content = re.sub(
+    r'( +)app\.kubernetes\.io/component: add-on\n'
+    r'\s+app\.kubernetes\.io/instance: (\S+)\n'
+    r'\s+app\.kubernetes\.io/name: http\n'
+    r'\s+app\.kubernetes\.io/part-of: keda',
+    r'\1app.kubernetes.io/name: http-add-on\n\1app.kubernetes.io/component: \2',
+    content,
+)
+
+# Replace hardcoded namespace env vars with fieldRef for dynamic namespace injection
+# TODO: remove after release of HTTP Addon 0.15.0
+content = re.sub(
+    r'( +- name: (?:KEDA_HTTP_OPERATOR_NAMESPACE|KEDA_HTTP_SCALER_TARGET_ADMIN_NAMESPACE))\n\s+value: keda',
+    r'\1\n              valueFrom:\n                fieldRef:\n                  fieldPath: metadata.namespace',
+    content,
+)
+with open(path, 'w') as f:
+    f.write(content)
+" "$ver" "$tmpfile"
 
 # Extract all CRDs from the manifest using a generic loop (same approach as relprep.sh)
 echo ""
@@ -79,7 +108,7 @@ python3 -c "
 import re, sys
 with open(sys.argv[1]) as f:
     content = f.read()
-docs = re.split(r'\n---\n', content)
+docs = re.split(r'^---$', content, flags=re.M)
 kept = []
 for doc in docs:
     stripped = doc.strip()
@@ -89,8 +118,8 @@ for doc in docs:
         continue
     if re.search(r'^kind:\s*Namespace', stripped, re.M):
         continue
-    kept.append(doc)
-result = '\n---\n'.join(kept)
+    kept.append(stripped)
+result = '\n---\n'.join(kept) + '\n'
 with open(sys.argv[2], 'w') as f:
     f.write(result)
 " "$tmpfile" resources/keda-http-addon.yaml
@@ -103,7 +132,7 @@ echo "Verifying manifest contents..."
 components=("interceptor" "operator" "scaler")
 for component in "${components[@]}"; do
   if grep -q "http-add-on-${component}" resources/keda-http-addon.yaml; then
-    img_ver=$(grep -oP "ghcr.io/kedacore/http-add-on-${component}:\K[0-9]+\.[0-9]+\.[0-9]+" resources/keda-http-addon.yaml | head -1)
+    img_ver=$(grep -oE "ghcr.io/kedacore/http-add-on-${component}:[0-9]+\.[0-9]+\.[0-9]+" resources/keda-http-addon.yaml | head -1 | cut -d: -f2)
     echo "  OK: ${component} component found (image version: ${img_ver})"
   else
     echo "  MISSING: ${component} component NOT found - manifest may be incomplete"

--- a/resources/keda-http-addon.yaml
+++ b/resources/keda-http-addon.yaml
@@ -161,10 +161,8 @@ spec:
       protocol: TCP
       targetPort: metrics-https
   selector:
-    app.kubernetes.io/component: add-on
-    app.kubernetes.io/instance: operator
-    app.kubernetes.io/name: http
-    app.kubernetes.io/part-of: keda
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: operator
   type: ClusterIP
 ---
 apiVersion: apps/v1
@@ -180,17 +178,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: add-on
-      app.kubernetes.io/instance: operator
-      app.kubernetes.io/name: http
-      app.kubernetes.io/part-of: keda
+      app.kubernetes.io/name: http-add-on
+      app.kubernetes.io/component: operator
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: add-on
-        app.kubernetes.io/instance: operator
-        app.kubernetes.io/name: http
-        app.kubernetes.io/part-of: keda
+        app.kubernetes.io/name: http-add-on
+        app.kubernetes.io/component: operator
     spec:
       containers:
         - args:
@@ -322,10 +316,8 @@ spec:
       protocol: TCP
       targetPort: admin
   selector:
-    app.kubernetes.io/component: add-on
-    app.kubernetes.io/instance: interceptor
-    app.kubernetes.io/name: http
-    app.kubernetes.io/part-of: keda
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: interceptor
 ---
 apiVersion: v1
 kind: Service
@@ -343,10 +335,8 @@ spec:
       protocol: TCP
       targetPort: metrics
   selector:
-    app.kubernetes.io/component: add-on
-    app.kubernetes.io/instance: interceptor
-    app.kubernetes.io/name: http
-    app.kubernetes.io/part-of: keda
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: interceptor
   type: ClusterIP
 ---
 apiVersion: v1
@@ -369,10 +359,8 @@ spec:
       protocol: TCP
       targetPort: proxy-tls
   selector:
-    app.kubernetes.io/component: add-on
-    app.kubernetes.io/instance: interceptor
-    app.kubernetes.io/name: http
-    app.kubernetes.io/part-of: keda
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: interceptor
   type: ClusterIP
 ---
 apiVersion: apps/v1
@@ -388,17 +376,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: add-on
-      app.kubernetes.io/instance: interceptor
-      app.kubernetes.io/name: http
-      app.kubernetes.io/part-of: keda
+      app.kubernetes.io/name: http-add-on
+      app.kubernetes.io/component: interceptor
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: add-on
-        app.kubernetes.io/instance: interceptor
-        app.kubernetes.io/name: http
-        app.kubernetes.io/part-of: keda
+        app.kubernetes.io/name: http-add-on
+        app.kubernetes.io/component: interceptor
     spec:
       containers:
         - args:
@@ -542,10 +526,8 @@ spec:
       protocol: TCP
       targetPort: grpc
   selector:
-    app.kubernetes.io/component: add-on
-    app.kubernetes.io/instance: external-scaler
-    app.kubernetes.io/name: http
-    app.kubernetes.io/part-of: keda
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: external-scaler
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -560,17 +542,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: add-on
-      app.kubernetes.io/instance: external-scaler
-      app.kubernetes.io/name: http
-      app.kubernetes.io/part-of: keda
+      app.kubernetes.io/name: http-add-on
+      app.kubernetes.io/component: external-scaler
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: add-on
-        app.kubernetes.io/instance: external-scaler
-        app.kubernetes.io/name: http
-        app.kubernetes.io/part-of: keda
+        app.kubernetes.io/name: http-add-on
+        app.kubernetes.io/component: external-scaler
     spec:
       containers:
         - args:


### PR DESCRIPTION
The HTTP Add-on is currently using labels incorrectly not following the actual purpose these labels have, see https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels . We plan to fix that in v1 as part of [http-add-on#1462](https://github.com/kedacore/http-add-on/issues/1462).
While we currently plan to delay the change in the Addon and Helm Chart repo until v1, we can already fix this in this repo to avoid breaking changes for users deploying KHA via the OLM operator.

**This is a breaking change for everyone who deployed the HTTP Addon already but I think this affects ~0 people right now.** Replacing it now is IMO way better than doing it later with more users.

The release prep script now rewrites these labels to proper name/component pairs.
I also added fixes for the previously manual changes to strip the empty YAML document (double ---) and the namespace reference.

Furthermore the sed and grep commands used flags not available on the macOS equivalents.
I am absolutely not a fan of the inline python script but think that it is the most portable solution.

Changes:
- Add label normalization and namespace fieldRef workarounds to the manifest post-processing step
- Replace sed -i and grep -oP with portable alternatives (macOS)
- Fix YAML document splitting to handle double --- separators
- Regenerate keda-http-addon.yaml with corrected labels


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

