### PR TITLE
bug: On OpenShift clusters, only take action to use centralized TLS profile if warranted by config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.39.1
 	github.com/open-policy-agent/cert-controller v0.16.0
-	github.com/openshift/api v0.0.0-20260421211856-fec28cd18ea9
+	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
+	github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2
+	github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/apiserver v0.35.2
@@ -65,9 +67,6 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/onsi/ginkgo/v2 v2.28.1 // indirect
-	github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2 // indirect
-	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -409,12 +409,12 @@ github.com/open-policy-agent/cert-controller v0.16.0 h1:/w+wAM9dylWGwhPnvfCgepyB
 github.com/open-policy-agent/cert-controller v0.16.0/go.mod h1:w5qBWYbc8HwyHI9VYAZ6YjWOcZtQ39A30I9W4X7pVVk=
 github.com/open-policy-agent/frameworks/constraint v0.0.0-20241101234656-e78c8abd754a h1:gQtOJ50XFyL2Xh3lDD9zP4KQ2PY4mZKQ9hDcWc81Sp8=
 github.com/open-policy-agent/frameworks/constraint v0.0.0-20241101234656-e78c8abd754a/go.mod h1:tI7nc6H6os2UYZRvSm9Y7bq4oMoXqhwA0WfnqKpoAgc=
-github.com/openshift/api v0.0.0-20260421211856-fec28cd18ea9 h1:SkOlGiiSmfv1sUt7SOKjEbyDfl3rB0C2QAGw3uTTULM=
-github.com/openshift/api v0.0.0-20260421211856-fec28cd18ea9/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
+github.com/openshift/api v0.0.0-20260521125114-09730f85d883 h1:So9yxVJRY+F1aVBjcDw6N3M4h30wyH/GpkazK8xT4TI=
+github.com/openshift/api v0.0.0-20260521125114-09730f85d883/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2 h1:GrZlVichOCE/lz8fg1+eNrAtkM0VSlqa9buuzN0vnb0=
 github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2/go.mod h1:XGabTMnNbz0M5Oa7IbscZp/jmcc7aHobvOCUWwkzKvM=
-github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 h1:9Pe6iVOMjt9CdA/vaKBNUSoEIjIe1po5Ha3ABRYXLJI=
-github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
+github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499 h1:Ff5OLOVD1Kj5RYEUHaBCOWGzqdEjygIGvReaj7uIxpc=
+github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -274,7 +275,9 @@ func (r *KedaControllerReconciler) enqueueOnTLSProfileChange(oldObj, newObj clie
 	}
 	oldProfile, oldErr := tlspkg.GetTLSProfileSpec(oldConfig.Spec.TLSSecurityProfile)
 	newProfile, newErr := tlspkg.GetTLSProfileSpec(newConfig.Spec.TLSSecurityProfile)
-	if oldErr == nil && newErr == nil && reflect.DeepEqual(oldProfile, newProfile) {
+	if oldErr == nil && newErr == nil &&
+		reflect.DeepEqual(oldProfile, newProfile) &&
+		oldConfig.Spec.TLSAdherence == newConfig.Spec.TLSAdherence {
 		return
 	}
 	r.enqueueKedaControllerReconcile(q)
@@ -282,11 +285,22 @@ func (r *KedaControllerReconciler) enqueueOnTLSProfileChange(oldObj, newObj clie
 
 // tlsEnvVarTransforms reads the current TLS profile from the APIServer via the manager cache and
 // returns Transformers that set KEDA_SERVICE_TLS_CIPHER_LIST and KEDA_SERVICE_MIN_TLS_VERSION in
-// all containers of all Deployment resources. Returns nil if the fetch fails.
+// all containers of all Deployment resources. Returns nil if the fetch fails or if the TLS
+// adherence policy does not require honoring the cluster-wide profile (in which case KEDA uses its
+// own defaults).
 func (r *KedaControllerReconciler) tlsEnvVarTransforms(ctx context.Context, logger logr.Logger) []mf.Transformer {
-	profile, err := tlspkg.FetchAPIServerTLSProfile(ctx, r.Client)
+	apiServer := &openshiftconfigv1.APIServer{}
+	if err := r.Get(ctx, client.ObjectKey{Name: tlspkg.APIServerName}, apiServer); err != nil {
+		logger.Error(err, "Failed to fetch APIServer; skipping TLS env var update")
+		return nil
+	}
+	if !libgocrypto.ShouldHonorClusterTLSProfile(apiServer.Spec.TLSAdherence) {
+		logger.V(4).Info("TLS adherence policy does not require honoring cluster TLS profile; skipping TLS env var injection", "policy", apiServer.Spec.TLSAdherence)
+		return nil
+	}
+	profile, err := tlspkg.GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
 	if err != nil {
-		logger.Error(err, "Failed to fetch TLS profile from APIServer; skipping TLS env var update")
+		logger.Error(err, "Failed to get TLS profile from APIServer; skipping TLS env var update")
 		return nil
 	}
 	minTLSVersion := strings.TrimPrefix(string(profile.MinTLSVersion), "Version")


### PR DESCRIPTION
The behavior added in #276 was slightly wrong in that it should only have activated if the OpenShift cluster config explicitly turned it on via a TLS Adherance Policy value of StrictAllComponents.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))