### PR TITLE
chore: exclude relprep-managed deps from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,32 +26,33 @@
       matchUpdateTypes: ["minor", "patch"],
       groupName: "Go Dependencies (non-major)",
     },
-    // Split minor and patch updates for k8s packages so patch fixes
-    // can be merged independently of k8s minor version bumps
-    {
-      matchManagers: ["gomod"],
-      matchPackageNames: [
-        "k8s.io/**",
-        "sigs.k8s.io/controller-runtime",
-        "sigs.k8s.io/controller-tools",
-      ],
-      separateMinorPatch: true,
-    },
-    // Group tightly coupled k8s packages updates for controlled K8s version support
-    {
-      matchManagers: ["gomod"],
-      matchPackageNames: [
-        "k8s.io/**",
-        "sigs.k8s.io/controller-runtime",
-        "sigs.k8s.io/controller-tools",
-      ],
-      // Patch updates are safe to be merged regularly in the catch-all group
-      matchUpdateTypes: ["minor", "major"],
-      groupName: "Kubernetes Dependencies",
-    },
     {
       matchManagers: ["pre-commit"],
       groupName: "Pre-commit Hooks",
+    },
+    // The following dependencies have their versions defined by upstream KEDA
+    // and are synchronized via hack/relprep.sh during release preparation.
+    // Updating these independently would conflict with that process.
+    {
+      matchManagers: ["gomod"],
+      matchPackageNames: [
+        "k8s.io/**",
+        "sigs.k8s.io/controller-runtime",
+        "sigs.k8s.io/controller-runtime/tools/setup-envtest",
+        "sigs.k8s.io/controller-tools",
+        "github.com/openshift/api",
+      ],
+      enabled: false,
+    },
+    // Go toolchain version synced with upstream KEDA by hack/relprep.sh.
+    {
+      matchDatasources: ["golang-version"],
+      enabled: false,
+    },
+    // keda-tools image tag synced with upstream KEDA by hack/relprep.sh.
+    {
+      matchPackageNames: ["ghcr.io/kedacore/keda-tools"],
+      enabled: false,
     },
   ],
   customManagers: [


### PR DESCRIPTION
Disable Renovate updates for dependencies that `hack/relprep.sh` synchronizes
with upstream KEDA during release preparation. These packages are intentionally
pinned to match the versions used by a specific KEDA release and should not be
updated independently:

- `k8s.io/*` — pinned to the Kubernetes version KEDA uses
- `sigs.k8s.io/controller-runtime`, `setup-envtest`, `controller-tools` — pinned to KEDA's versions
- `github.com/openshift/api` — pinned to the OpenShift release branch matching the k8s version
- Go toolchain version (`go` directive and `go-version` in CI) — synced with KEDA
- `ghcr.io/kedacore/keda-tools` image tag — synced with KEDA's Dockerfile

Also removes two now-redundant `packageRules` entries that grouped k8s/sigs
packages for minor/patch separation, since those packages are now disabled
entirely.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))

Related to #291