### PR TITLE
fix: use heredoc for multi-line GITHUB_OUTPUT in version-diff

### DIFF
--- a/.github/workflows/version-diff.yml
+++ b/.github/workflows/version-diff.yml
@@ -165,10 +165,6 @@ jobs:
               POSTFIX=$'\n\n```\n\n</details>'
               first_line="Diff \`$new_file\` \& \`$old_file\`"
               diff_text="${first_line}${PREFIX}${diff_text}${POSTFIX}"
-              ## set file ready for github comment
-              diff_text="${diff_text//'%'/'%25'}"
-              diff_text="${diff_text//$'\n'/'%0A'}"
-              diff_text="${diff_text//$'\r'/'%0D'}"
               if [ ${#diff_text} -ge 65536 ]; then
                 echo "$diff_text"
                 diff_text="limit exceeded"
@@ -177,7 +173,11 @@ jobs:
           else
             diff_text="File \`$new_file\` wasn't found in previous version, its brand new!"
           fi
-          echo "body=$diff_text" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<DIFF_EOF"
+            echo "$diff_text"
+            echo "DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
           echo "old_file=$old_file" >> "$GITHUB_OUTPUT"
 
       - name: Find comment


### PR DESCRIPTION
The migration from `::set-output` to `$GITHUB_OUTPUT` (in #283) kept the percent-encoding (`%0A`, `%0D`, `%25`) that was only needed by the old command. With `$GITHUB_OUTPUT`, multi-line values must use heredoc delimiters instead, otherwise the encoded characters appear literally in PR diff comments.

Example of broken output: https://github.com/kedacore/keda-olm-operator/pull/298#issuecomment-4720205912

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))

Fixes #