### PR TITLE
fix: remove keda-tools container from CI workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -16,7 +16,6 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
-    container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -56,7 +56,6 @@ jobs:
       contents: read
       packages: write
 
-    container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,7 +16,6 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
-    container: ghcr.io/kedacore/keda-tools:1.25.6
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/hack/relprep.sh
+++ b/hack/relprep.sh
@@ -57,15 +57,6 @@ echo
 echo 'Running go mod tidy (pass 1)'
 go mod tidy
 
-echo "Getting tag for keda-tools used to build KEDA version $ver"
-bttag=$(curl -s "https://raw.githubusercontent.com/kedacore/keda/v${ver}/Dockerfile" | sed -n 's#^FROM.* ghcr.io/kedacore/keda-tools:\([0-9][0-9.]*\) AS builder$#\1#p;T;q')
-
-echo "Updating keda-tools tag to $bttag"
-while read f; do
-  echo " $f"
-  sed -i "s#ghcr.io/kedacore/keda-tools:[0-9][0-9.]*#ghcr.io/kedacore/keda-tools:$bttag#g" "$f"
-done < <(git grep -l "ghcr.io/kedacore/keda-tools:[0-9]")
-
 echo "Updating resources from KEDA $ver release"
 curl -L "https://github.com/kedacore/keda/releases/download/v${ver}/keda-${ver}.yaml" | sed 's/\r//g' > resources/keda.yaml
 


### PR DESCRIPTION
This PR fixes the failing builds on main, see e.g. this [failed run](https://github.com/kedacore/keda-olm-operator/actions/runs/27527662399/job/81358308929#step:8:256).

The cosign-installer action requires envsubst, which is missing from the keda-tools container, causing the "Install Cosign" step to fail with "envsubst: command not found". The keda-tools container provides Go, docker CLI, kubectl, operator-sdk, and other tools, none of which are needed by these CI jobs since they use actions/setup-go and the ubuntu-latest runner already provides docker.

I don't see any benefit in using this image as we don't have self-hosted runners where all of these deps would be needed/useful.

**I can rebase this PR after the merge of #298 as there will be conflicts.**

### Changes
- Remove container: ghcr.io/kedacore/keda-tools from main-build, pr-tests, and release-build workflows
- Remove keda-tools tag sync from hack/relprep.sh (now dead code)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
