### PR TITLE
fix: do not add app.kubernetes.io/version to Deployment selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/c
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-    $(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+    $(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
@@ -192,7 +192,7 @@ bundle: manifests operator-sdk	## Generate bundle manifests and metadata, then v
 	cd config/manager && \
 		$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-  	$(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+  	$(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle

--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -44,8 +44,10 @@ resources:
 - ../general
 - ../rbac
 - ../manager
+commonLabels:
+  app.kubernetes.io/part-of: keda-olm-operator
 labels:
 - pairs:
-    app.kubernetes.io/part-of: keda-olm-operator
     app.kubernetes.io/version: main
-  includeSelectors: true
+  includeSelectors: false
+  includeTemplates: true


### PR DESCRIPTION
## Summary

Fixes OLM in-place upgrade failures when `app.kubernetes.io/version` is added to the operator Deployment `spec.selector.matchLabels` (immutable field).

- Remove version from Deployment selector in bundle CSV
- Keep version on Deployment metadata and pod template labels
- Fix kustomize/Makefile so future bundles do not inject version into selectors

Related: openshift/custom-metrics-autoscaler-operator#88, AUTOSCALE-825

## Test plan

- [x] Validated on OpenShift: CSV upgrade from Failed → Succeeded after selector fix
- [ ] `make bundle` — verify generated Deployment selector has no `app.kubernetes.io/version`
- [ ] OLM upgrade from prior release succeeds without `InstallComponentFailed`