### PR TITLE
Add e2e upgrade test for KEDA operator

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -129,3 +129,75 @@ jobs:
           kubectl get csv,sub,installplan -n keda 2>/dev/null || true
           echo "=== Operator logs ==="
           kubectl logs -n keda -l app.kubernetes.io/part-of=keda-olm-operator --tail=200 || true
+
+  e2e-upgrade:
+    name: E2E Upgrade Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26'
+
+      - name: Create kind cluster with local registry
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: "v0.32.0"
+          # renovate: datasource=docker depName=kindest/node
+          KIND_NODE_VERSION: "v1.36.1"
+        with:
+          cluster_name: kind
+          node_image: kindest/node:${{ env.KIND_NODE_VERSION }}
+          registry: true
+          version: ${{ env.KIND_VERSION }}
+
+      - name: Install OLM
+        env:
+          # renovate: datasource=github-releases depName=operator-framework/operator-lifecycle-manager
+          OLM_VERSION: "v0.45.0"
+        run: make operator-sdk && ./bin/operator-sdk olm install --version "$OLM_VERSION"
+
+      - name: Build operator and bundle images
+        run: make e2e-olm-upgrade-build
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Install previous operator version
+        run: make e2e-olm-upgrade-install
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Deploy workloads under previous version
+        run: make e2e-upgrade-test-pre-ci
+
+      - name: Upgrade operator to current build
+        run: make e2e-olm-upgrade-apply
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Verify workloads survive upgrade
+        run: make e2e-upgrade-test-post-ci
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          echo "=== All pods ==="
+          kubectl get pods -A
+          echo "=== Pods in keda namespace ==="
+          kubectl describe pods -n keda
+          echo "=== OLM resources ==="
+          kubectl get csv,sub,installplan -n keda 2>/dev/null || true
+          echo "=== Operator logs ==="
+          kubectl logs -n keda -l app.kubernetes.io/part-of=keda-olm-operator --tail=200 || true
+          echo "=== KEDA operator logs ==="
+          kubectl logs -n keda deployment/keda-operator --tail=200 || true
+          echo "=== Workload namespace ==="
+          kubectl get all -n keda-upgrade-test 2>/dev/null || true
+          echo "=== ScaledObjects ==="
+          kubectl get scaledobjects -n keda-upgrade-test -o yaml 2>/dev/null || true
+          echo "=== HPAs ==="
+          kubectl get hpa -n keda-upgrade-test -o yaml 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -77,17 +77,74 @@ test: manifests generate
 
 .PHONY: e2e-test
 e2e-test: ## Run e2e smoke tests against existing cluster.
-	go test -tags=e2e -count=1 -timeout=10m -v ./test/e2e/...
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaControllerLifecycle ./test/e2e/...
 
 .PHONY: e2e-test-ci
 e2e-test-ci: ## Run e2e smoke tests (CI mode with GitHub Actions output).
-	go tool gotestsum --rerun-fails=2 --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m
+	go tool gotestsum --rerun-fails=2 --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaControllerLifecycle
+
+.PHONY: e2e-upgrade-test-pre
+e2e-upgrade-test-pre: ## Run pre-upgrade e2e test: deploy workloads under the previous KEDA version.
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaUpgradeSetup ./test/e2e/...
+
+.PHONY: e2e-upgrade-test-pre-ci
+e2e-upgrade-test-pre-ci: ## Run pre-upgrade e2e test (CI mode).
+	go tool gotestsum --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaUpgradeSetup
+
+.PHONY: e2e-upgrade-test-post
+e2e-upgrade-test-post: ## Run post-upgrade e2e test: verify workloads survived the upgrade.
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaUpgradeVerify ./test/e2e/...
+
+.PHONY: e2e-upgrade-test-post-ci
+e2e-upgrade-test-post-ci: ## Run post-upgrade e2e test (CI mode).
+	go tool gotestsum --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaUpgradeVerify
 
 .PHONY: e2e-olm-setup
 e2e-olm-setup: build bundle docker-build docker-push bundle-build bundle-push ## Deploy operator via OLM for e2e testing.
 	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply --server-side -f -
 	kubectl annotate namespace keda keda-olm-operator/create-default-controller=skip --overwrite
 	$(OPERATOR_SDK) run bundle $(BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
+	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
+
+# Previous KEDA version used as the upgrade starting point, auto-detected from
+# the latest GitHub release. Uses deferred simple variable expansion so the shell
+# command runs at most once and only when actually referenced.
+E2E_PREVIOUS_KEDA_VERSION ?= $(eval E2E_PREVIOUS_KEDA_VERSION := $$(shell curl -s https://api.github.com/repos/kedacore/keda-olm-operator/releases/latest | jq -r '.name[1:]'))$(E2E_PREVIOUS_KEDA_VERSION)
+# Synthetic semver for the upgrade bundle CSV so OLM sees a distinct, newer entry.
+E2E_UPGRADE_CSV_FAKE_VERSION ?= 1000.0.0
+E2E_PREVIOUS_BUNDLE = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-olm-operator-bundle:$(E2E_PREVIOUS_KEDA_VERSION)
+
+.PHONY: e2e-olm-upgrade-build
+e2e-olm-upgrade-build: operator-sdk ## Build operator and both bundle images for upgrade testing.
+	$(MAKE) build docker-build docker-push
+	printf 'FROM scratch\nCOPY manifests/ /manifests/\nCOPY metadata/ /metadata/\n' | \
+		docker build -f - -t $(E2E_PREVIOUS_BUNDLE) \
+		--label operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
+		--label operators.operatorframework.io.bundle.manifests.v1=manifests/ \
+		--label operators.operatorframework.io.bundle.metadata.v1=metadata/ \
+		--label operators.operatorframework.io.bundle.package.v1=keda \
+		--label operators.operatorframework.io.bundle.channels.v1=stable \
+		--label operators.operatorframework.io.bundle.channel.default.v1=stable \
+		keda/$(E2E_PREVIOUS_KEDA_VERSION)
+	docker push $(E2E_PREVIOUS_BUNDLE)
+	$(MAKE) bundle
+	cd bundle/manifests && \
+		sed -i 's/^  name: keda\.v.*/  name: keda.v$(E2E_UPGRADE_CSV_FAKE_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i 's/^  version: .*/  version: $(E2E_UPGRADE_CSV_FAKE_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i 's/replaces: keda\.v.*/replaces: keda.v$(E2E_PREVIOUS_KEDA_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i '/matchLabels:/,/name:/{/app.kubernetes.io\/version:/d}' keda.clusterserviceversion.yaml
+	$(MAKE) bundle-build bundle-push
+
+.PHONY: e2e-olm-upgrade-install
+e2e-olm-upgrade-install: operator-sdk ## Install the previous operator version via OLM.
+	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply --server-side -f -
+	kubectl annotate namespace keda keda-olm-operator/create-default-controller=skip --overwrite
+	$(OPERATOR_SDK) run bundle $(E2E_PREVIOUS_BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
+	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
+
+.PHONY: e2e-olm-upgrade-apply
+e2e-olm-upgrade-apply: operator-sdk ## Upgrade the operator to the current bundle.
+	$(OPERATOR_SDK) run bundle-upgrade $(BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
 	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
 
 .PHONY: e2e-olm-cleanup

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,360 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+)
+
+const (
+	workloadNamespace = "keda-upgrade-test"
+
+	scaledDeploymentName = "test-consumer"
+	scaledObjectName     = "test-scaledobject"
+
+	upgradePollInterval = 2 * time.Second
+	upgradePollTimeout  = 5 * time.Minute
+	scalingPollTimeout  = 3 * time.Minute
+)
+
+var (
+	scaledObjectGVK = schema.GroupVersionKind{
+		Group:   "keda.sh",
+		Version: "v1alpha1",
+		Kind:    "ScaledObject",
+	}
+)
+
+// TestKedaUpgradeSetup runs under the previous KEDA operator version (installed
+// by e2e-olm-upgrade-install). It creates a KedaController, deploys a workload
+// with a ScaledObject, and verifies the scaling pipeline works. All resources
+// are left in place so TestKedaUpgradeVerify can check them after the upgrade.
+func TestKedaUpgradeSetup(t *testing.T) {
+	ctx := t.Context()
+	c := newClient(t)
+
+	step(t, "install KEDA via KedaController", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "keda",
+				Namespace: namespace,
+			},
+		}
+		if err := c.Create(ctx, kc); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating KedaController: %v", err)
+		}
+	})
+
+	step(t, "core KEDA deployments become ready", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+	})
+
+	step(t, "KedaController status shows success", func(t *testing.T) {
+		version := waitForKedaControllerSuccess(t, ctx, c)
+		t.Logf("pre-upgrade KEDA version: %s", version)
+	})
+
+	step(t, "log pre-upgrade deployment images", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "create workload namespace", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: workloadNamespace},
+		}
+		if err := c.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating workload namespace: %v", err)
+		}
+	})
+
+	step(t, "deploy scaling workload", func(t *testing.T) {
+		createScalingWorkload(t, ctx, c)
+	})
+
+	step(t, "ScaledObject becomes ready under previous version", func(t *testing.T) {
+		waitForScaledObjectReady(t, ctx, c)
+	})
+
+	step(t, "HPA created under previous version", func(t *testing.T) {
+		verifyHPACreated(t, ctx, c)
+	})
+}
+
+// TestKedaUpgradeVerify runs after the operator has been upgraded to the
+// current build (by e2e-olm-upgrade-apply). It verifies that the ScaledObject
+// and HPA created by TestKedaUpgradeSetup are still functional, then cleans up.
+func TestKedaUpgradeVerify(t *testing.T) {
+	ctx := t.Context()
+	c := newClient(t)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		cleanupUpgradeResources(t, cleanupCtx, c)
+	})
+
+	step(t, "core KEDA deployments ready after upgrade", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+	})
+
+	step(t, "KedaController status shows success after upgrade", func(t *testing.T) {
+		version := waitForKedaControllerSuccess(t, ctx, c)
+		t.Logf("post-upgrade KEDA version: %s", version)
+	})
+
+	step(t, "log post-upgrade deployment images", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "pre-existing ScaledObject still ready after upgrade", func(t *testing.T) {
+		waitForScaledObjectReady(t, ctx, c)
+	})
+
+	step(t, "pre-existing HPA still present after upgrade", func(t *testing.T) {
+		verifyHPACreated(t, ctx, c)
+	})
+
+	step(t, "cleanup upgrade test resources", func(t *testing.T) {
+		cleanupUpgradeResources(t, ctx, c)
+	})
+}
+
+func waitForKedaControllerSuccess(t *testing.T, ctx context.Context, c client.Client) string {
+	t.Helper()
+	var kc kedav1alpha1.KedaController
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, upgradePollTimeout, true, func(ctx context.Context) (bool, error) {
+		if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, &kc); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("checking KedaController status: %w", err)
+		}
+		return kc.Status.Phase == kedav1alpha1.PhaseInstallSucceeded, nil
+	})
+	if err != nil {
+		t.Fatalf("KedaController did not reach %q: %v", kedav1alpha1.PhaseInstallSucceeded, err)
+	}
+	return kc.Status.Version
+}
+
+func createScalingWorkload(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	replicas := int32(1)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scaledDeploymentName,
+			Namespace: workloadNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": scaledDeploymentName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": scaledDeploymentName},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "consumer",
+							Image:   "registry.k8s.io/pause:3.9",
+							Command: []string{"/pause"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, dep); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating workload deployment: %v", err)
+	}
+
+	t.Log("waiting for workload deployment to become ready")
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, upgradePollTimeout, true, func(ctx context.Context) (bool, error) {
+		d := &appsv1.Deployment{}
+		if err := c.Get(ctx, client.ObjectKey{Name: scaledDeploymentName, Namespace: workloadNamespace}, d); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, cond := range d.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("workload deployment did not become ready: %v", err)
+	}
+
+	so := newScaledObject()
+	if err := c.Create(ctx, so); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating ScaledObject: %v", err)
+	}
+}
+
+func newScaledObject() *unstructured.Unstructured {
+	so := &unstructured.Unstructured{}
+	so.SetGroupVersionKind(scaledObjectGVK)
+	so.SetName(scaledObjectName)
+	so.SetNamespace(workloadNamespace)
+
+	so.Object["spec"] = map[string]any{
+		"scaleTargetRef": map[string]any{
+			"name": scaledDeploymentName,
+		},
+		"minReplicaCount": int64(1),
+		"maxReplicaCount": int64(5),
+		"cooldownPeriod":  int64(10),
+		"triggers": []any{
+			map[string]any{
+				"type":       "cpu",
+				"metricType": string(autoscalingv2.UtilizationMetricType),
+				"metadata": map[string]any{
+					"value": "50",
+				},
+			},
+		},
+	}
+	return so
+}
+
+func waitForScaledObjectReady(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+	t.Log("waiting for ScaledObject to become ready")
+
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, scalingPollTimeout, true, func(ctx context.Context) (bool, error) {
+		so := &unstructured.Unstructured{}
+		so.SetGroupVersionKind(scaledObjectGVK)
+		if err := c.Get(ctx, client.ObjectKey{Name: scaledObjectName, Namespace: workloadNamespace}, so); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting ScaledObject: %w", err)
+		}
+
+		conditions, found, err := unstructured.NestedSlice(so.Object, "status", "conditions")
+		if err != nil || !found {
+			return false, nil
+		}
+
+		for _, c := range conditions {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			condType, _, _ := unstructured.NestedString(cond, "type")
+			condStatus, _, _ := unstructured.NestedString(cond, "status")
+			if condType == "Ready" && condStatus == "True" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("ScaledObject %s/%s did not become ready: %v", workloadNamespace, scaledObjectName, err)
+	}
+}
+
+func verifyHPACreated(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	hpaName := "keda-hpa-" + scaledObjectName
+	t.Logf("checking HPA %s/%s exists", workloadNamespace, hpaName)
+
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, scalingPollTimeout, true, func(ctx context.Context) (bool, error) {
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		if err := c.Get(ctx, client.ObjectKey{Name: hpaName, Namespace: workloadNamespace}, hpa); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting HPA: %w", err)
+		}
+
+		t.Logf("HPA %s: currentReplicas=%d, desiredReplicas=%d, minReplicas=%d, maxReplicas=%d",
+			hpaName,
+			hpa.Status.CurrentReplicas,
+			hpa.Status.DesiredReplicas,
+			*hpa.Spec.MinReplicas,
+			hpa.Spec.MaxReplicas)
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("HPA %s/%s was not created by KEDA: %v", workloadNamespace, hpaName, err)
+	}
+}
+
+func cleanupUpgradeResources(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	so := &unstructured.Unstructured{}
+	so.SetGroupVersionKind(scaledObjectGVK)
+	so.SetName(scaledObjectName)
+	so.SetNamespace(workloadNamespace)
+	if err := c.Delete(ctx, so); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete ScaledObject: %v", err)
+	}
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scaledDeploymentName,
+			Namespace: workloadNamespace,
+		},
+	}
+	if err := c.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete workload deployment: %v", err)
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: workloadNamespace}}
+	if err := c.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete workload namespace: %v", err)
+	}
+
+	kc := &kedav1alpha1.KedaController{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+		return
+	}
+	if err := c.Delete(ctx, kc); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete KedaController: %v", err)
+		return
+	}
+	waitForDeploymentGone(t, ctx, c, coreDeployments[0])
+}


### PR DESCRIPTION
Add an end-to-end test that verifies KEDA upgrades work correctly.

The test installs the previous operator version (2.20.1) via OLM, deploys
a KedaController and a ScaledObject workload under that version, then
upgrades to the current build and verifies the pre-existing resources
survived the upgrade:

- Core KEDA deployments become ready under the previous version
- A ScaledObject with a CPU trigger is created and becomes ready, with
  a corresponding HPA created by KEDA
- After the OLM upgrade, the same ScaledObject and HPA remain functional
- KedaController status reports success with the new version

The CI workflow orchestrates the full upgrade sequence:
1. Build operator and both bundle images (`e2e-olm-upgrade-build`)
2. Install the previous version (`e2e-olm-upgrade-install`)
3. Deploy workloads and verify (`e2e-upgrade-test-pre-ci` / `TestKedaUpgradeSetup`)
4. Upgrade to the current build (`e2e-olm-upgrade-apply`)
5. Verify workloads survived (`e2e-upgrade-test-post-ci` / `TestKedaUpgradeVerify`)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))