### PR TITLE
Ensure Prometheus monitoring RBAC on OpenShift CLI install

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -433,6 +433,14 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
+	if err := r.ensurePrometheusMonitoringRBAC(ctx, logger, instance); err != nil {
+		status.MarkInstallFailed("Not able to ensure Prometheus monitoring RBAC")
+		if statusErr := util.UpdateKedaControllerStatus(ctx, r.Client, instance, status); statusErr != nil {
+			err = fmt.Errorf("got error: %s and then another: %s", err, statusErr)
+		}
+		return ctrl.Result{}, err
+	}
+
 	status.Version = version.Version
 	status.MarkInstallSucceeded(fmt.Sprintf("KEDA v%s is installed in namespace '%s'", version.Version, r.resourceNamespace))
 	if err := util.UpdateKedaControllerStatus(ctx, r.Client, instance, status); err != nil {
@@ -1279,7 +1287,8 @@ func (r *KedaControllerReconciler) ensureOpenshiftCABundleConfigMap(ctx context.
 	}
 
 	if err := controllerutil.SetControllerReference(instance, configMap, r.Scheme); err != nil {
-		if !goerrors.Is(err, &controllerutil.AlreadyOwnedError{}) {
+		var alreadyOwnedErr *controllerutil.AlreadyOwnedError
+		if !goerrors.As(err, &alreadyOwnedErr) {
 			logger.Error(err, "Failed to check Controller Reference for ConfigMap")
 			return err
 		}
@@ -1349,7 +1358,8 @@ func (r *KedaControllerReconciler) ensureMetricsServerAuditLogPolicyConfigMap(ct
 	}
 
 	if err := controllerutil.SetControllerReference(instance, configMap, r.Scheme); err != nil {
-		if !goerrors.Is(err, &controllerutil.AlreadyOwnedError{}) {
+		var alreadyOwnedErr *controllerutil.AlreadyOwnedError
+		if !goerrors.As(err, &alreadyOwnedErr) {
 			logger.Error(err, "failed to check Controller Reference for ConfigMap")
 			return err
 		}

--- a/internal/controller/keda/prometheus_rbac.go
+++ b/internal/controller/keda/prometheus_rbac.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"context"
+	goerrors "errors"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+	"github.com/kedacore/keda-olm-operator/internal/controller/keda/util"
+)
+
+const (
+	clusterMonitoringLabel          = "openshift.io/cluster-monitoring"
+	prometheusMonitoringSAName      = "prometheus-k8s"
+	prometheusMonitoringSANamespace = "openshift-monitoring"
+)
+
+func prometheusRBACName(namespace string) string {
+	return namespace + "-prometheus"
+}
+
+func prometheusRoleRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services", "endpoints", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+}
+
+func namespaceHasClusterMonitoringEnabled(ns *corev1.Namespace) bool {
+	if ns == nil || ns.Labels == nil {
+		return false
+	}
+	return ns.Labels[clusterMonitoringLabel] == "true"
+}
+
+// ensurePrometheusMonitoringRBAC creates a Role and RoleBinding that allow
+// OpenShift cluster monitoring (prometheus-k8s) to discover scrape targets in
+// the operator namespace. The OpenShift web console creates the same objects
+// during OperatorHub installs; this ensures CLI installs behave identically.
+// On non-OpenShift clusters or when cluster monitoring is not enabled for the
+// namespace, this function is a no-op.
+func (r *KedaControllerReconciler) ensurePrometheusMonitoringRBAC(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
+	if !util.RunningOnOpenshift(ctx, logger, r.Client) {
+		return nil
+	}
+
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(4).Info("Operator namespace not found, skipping Prometheus monitoring RBAC")
+			return nil
+		}
+		return err
+	}
+
+	if !namespaceHasClusterMonitoringEnabled(ns) {
+		logger.V(4).Info("Cluster monitoring not enabled for namespace, skipping Prometheus monitoring RBAC", "namespace", instance.Namespace)
+		return nil
+	}
+
+	rbacName := prometheusRBACName(instance.Namespace)
+	logger.Info("Ensuring Prometheus monitoring RBAC exists", "namespace", instance.Namespace, "name", rbacName)
+
+	if err := r.ensurePrometheusRole(ctx, logger, instance, rbacName); err != nil {
+		return err
+	}
+	return r.ensurePrometheusRoleBinding(ctx, logger, instance, rbacName)
+}
+
+func (r *KedaControllerReconciler) ensurePrometheusRole(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController, rbacName string) error {
+	desired := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbacName,
+			Namespace: instance.Namespace,
+		},
+		Rules: prometheusRoleRules(),
+	}
+
+	existing := &rbacv1.Role{}
+	err := r.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: instance.Namespace}, existing)
+	if errors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+			logger.Error(err, "Failed to set controller reference for Prometheus Role")
+			return err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			logger.Error(err, "Failed to create Prometheus monitoring Role")
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	needsUpdate := false
+
+	if !reflect.DeepEqual(existing.Rules, desired.Rules) {
+		existing.Rules = desired.Rules
+		needsUpdate = true
+	}
+
+	if err := controllerutil.SetControllerReference(instance, existing, r.Scheme); err != nil {
+		var alreadyOwnedErr *controllerutil.AlreadyOwnedError
+		if !goerrors.As(err, &alreadyOwnedErr) {
+			logger.Error(err, "Failed to set controller reference for Prometheus Role")
+			return err
+		}
+	} else {
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if err := r.Update(ctx, existing); err != nil {
+			logger.Error(err, "Failed to update Prometheus monitoring Role")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *KedaControllerReconciler) ensurePrometheusRoleBinding(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController, rbacName string) error {
+	desired := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbacName,
+			Namespace: instance.Namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     rbacName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      prometheusMonitoringSAName,
+				Namespace: prometheusMonitoringSANamespace,
+			},
+		},
+	}
+
+	existing := &rbacv1.RoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: instance.Namespace}, existing)
+	if errors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+			logger.Error(err, "Failed to set controller reference for Prometheus RoleBinding")
+			return err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			logger.Error(err, "Failed to create Prometheus monitoring RoleBinding")
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// RoleRef is immutable in the Kubernetes API. If it has drifted,
+	// we must delete the RoleBinding and recreate it.
+	if !reflect.DeepEqual(existing.RoleRef, desired.RoleRef) {
+		if err := r.Delete(ctx, existing); err != nil {
+			logger.Error(err, "Failed to delete Prometheus monitoring RoleBinding with stale RoleRef")
+			return err
+		}
+		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+			logger.Error(err, "Failed to set controller reference for Prometheus RoleBinding")
+			return err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			logger.Error(err, "Failed to recreate Prometheus monitoring RoleBinding")
+			return err
+		}
+		return nil
+	}
+
+	needsUpdate := false
+
+	if !reflect.DeepEqual(existing.Subjects, desired.Subjects) {
+		existing.Subjects = desired.Subjects
+		needsUpdate = true
+	}
+
+	if err := controllerutil.SetControllerReference(instance, existing, r.Scheme); err != nil {
+		var alreadyOwnedErr *controllerutil.AlreadyOwnedError
+		if !goerrors.As(err, &alreadyOwnedErr) {
+			logger.Error(err, "Failed to set controller reference for Prometheus RoleBinding")
+			return err
+		}
+	} else {
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if err := r.Update(ctx, existing); err != nil {
+			logger.Error(err, "Failed to update Prometheus monitoring RoleBinding")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/keda/prometheus_rbac_test.go
+++ b/internal/controller/keda/prometheus_rbac_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPrometheusRBACName(t *testing.T) {
+	tests := []struct {
+		namespace string
+		want      string
+	}{
+		{"openshift-keda", "openshift-keda-prometheus"},
+		{"keda", "keda-prometheus"},
+		{"my-namespace", "my-namespace-prometheus"},
+	}
+	for _, tt := range tests {
+		if got := prometheusRBACName(tt.namespace); got != tt.want {
+			t.Errorf("prometheusRBACName(%q) = %q, want %q", tt.namespace, got, tt.want)
+		}
+	}
+}
+
+func TestPrometheusRoleRules(t *testing.T) {
+	rules := prometheusRoleRules()
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+
+	rule := rules[0]
+
+	if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "" {
+		t.Fatalf("unexpected APIGroups: %v", rule.APIGroups)
+	}
+
+	wantResources := map[string]bool{"services": true, "endpoints": true, "pods": true}
+	if len(rule.Resources) != len(wantResources) {
+		t.Fatalf("expected %d resources, got %d: %v", len(wantResources), len(rule.Resources), rule.Resources)
+	}
+	for _, res := range rule.Resources {
+		if !wantResources[res] {
+			t.Errorf("unexpected resource %q", res)
+		}
+	}
+
+	wantVerbs := map[string]bool{"get": true, "list": true, "watch": true}
+	if len(rule.Verbs) != len(wantVerbs) {
+		t.Fatalf("expected %d verbs, got %d: %v", len(wantVerbs), len(rule.Verbs), rule.Verbs)
+	}
+	for _, verb := range rule.Verbs {
+		if !wantVerbs[verb] {
+			t.Errorf("unexpected verb %q", verb)
+		}
+	}
+}
+
+func TestNamespaceHasClusterMonitoringEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		ns   *corev1.Namespace
+		want bool
+	}{
+		{
+			name: "label set to true",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{clusterMonitoringLabel: "true"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "label set to false",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{clusterMonitoringLabel: "false"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label missing",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil labels",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			want: false,
+		},
+		{
+			name: "nil namespace",
+			ns:   nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := namespaceHasClusterMonitoringEnabled(tt.ns); got != tt.want {
+				t.Errorf("namespaceHasClusterMonitoringEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrometheusRoleBindingSubjects(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      prometheusMonitoringSAName,
+				Namespace: prometheusMonitoringSANamespace,
+			},
+		},
+	}
+
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("expected 1 subject, got %d", len(rb.Subjects))
+	}
+	subject := rb.Subjects[0]
+	if subject.Kind != rbacv1.ServiceAccountKind {
+		t.Errorf("subject.Kind = %q, want %q", subject.Kind, rbacv1.ServiceAccountKind)
+	}
+	if subject.Name != "prometheus-k8s" {
+		t.Errorf("subject.Name = %q, want %q", subject.Name, "prometheus-k8s")
+	}
+	if subject.Namespace != "openshift-monitoring" {
+		t.Errorf("subject.Namespace = %q, want %q", subject.Namespace, "openshift-monitoring")
+	}
+}


### PR DESCRIPTION
Ensure Prometheus monitoring RBAC for OpenShift CLI installs.

When the KEDA OLM Operator is installed on OpenShift via CLI (`kubectl apply`
with Subscription + OperatorGroup YAMLs, or `make deploy`), the
`{namespace}-prometheus` Role and RoleBinding are not created in the operator
namespace. This causes `prometheus-k8s` pods to stream forbidden errors because
the ServiceAccount lacks permission to discover scrape targets.

The OpenShift web console normally creates these RBAC objects during OperatorHub
installs (see [openshift/console#5529](https://github.com/openshift/console/pull/5529)),
but CLI installs bypass the console entirely, leaving a gap.

This PR adds an `ensurePrometheusMonitoringRBAC` step to the reconcile loop that
creates a Role and RoleBinding named `{namespace}-prometheus`, granting the
`prometheus-k8s` ServiceAccount `get`/`list`/`watch` on services, endpoints, and
pods. It is gated behind `RunningOnOpenshift()` and the
`openshift.io/cluster-monitoring: "true"` namespace label, so on vanilla
Kubernetes it is a no-op.

Based on [openshift/custom-metrics-autoscaler-operator#87](https://github.com/openshift/custom-metrics-autoscaler-operator/pull/87)
with improvements: correct handling of immutable RoleRef (delete + recreate
instead of update), controller reference changes persisted in the same update
call, and additional unit test coverage.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))