### PR TITLE
fix: grant operator core "" events RBAC for event recording

### DIFF
--- a/hack/relprep.sh
+++ b/hack/relprep.sh
@@ -60,6 +60,29 @@ go mod tidy
 echo "Updating resources from KEDA $ver release"
 curl -L "https://github.com/kedacore/keda/releases/download/v${ver}/keda-${ver}.yaml" | sed 's/\r//g' > resources/keda.yaml
 
+# Workaround: since KEDA 2.20.0 the bundled manifests grant the operator the
+# 'events' resource only on the events.k8s.io API group (kedacore/keda#7781).
+# client-go's event broadcaster still writes events (including leader-election
+# events) to the core ("") group as well (kubernetes/kubernetes#94857), so with
+# only events.k8s.io granted, event recording is denied (kedacore/keda#883-like).
+# Restore the core group alongside events.k8s.io until the upstream KEDA manifest
+# is fixed.
+echo "Ensuring the operator 'events' RBAC rule includes the core \"\" API group"
+awk '
+  { line[NR] = $0 }
+  END {
+    for (i = 1; i <= NR; i++) {
+      # Insert the core ("") API group before the events.k8s.io events rule,
+      # unless it is already present (idempotent).
+      if (line[i] == "  - events.k8s.io" && line[i+1] == "  resources:" && \
+          line[i+2] == "  - events" && line[i-1] != "  - \"\"") {
+        print "  - \"\""
+      }
+      print line[i]
+    }
+  }
+' resources/keda.yaml > resources/keda.yaml.tmp && mv resources/keda.yaml.tmp resources/keda.yaml
+
 echo "Finding previous release version"
 prev=$(ls keda/ | grep -v "^${ver//./\\.}$" | sort --version-sort | tail -1)
 

--- a/resources/keda.yaml
+++ b/resources/keda.yaml
@@ -11532,6 +11532,7 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
   - events.k8s.io
   resources:
   - events


### PR DESCRIPTION
Since KEDA 2.20.0 the bundled release manifests grant the `keda-operator` the `events` resource only on the `events.k8s.io` API group ([kedacore/keda#7781](https://github.com/kedacore/keda/pull/7781)). However, client-go's event broadcaster still writes events to the legacy core (`""`) API group as well ([kubernetes/kubernetes#94857](https://github.com/kubernetes/kubernetes/issues/94857)), so with only `events.k8s.io` granted, event recording is denied with:

```
"Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:keda:keda-operator\" cannot create resource \"events\" in API group \"\" ..."
```

This breaks all native Kubernetes event recording — including controller-runtime leader-election events and ScaledObject events such as `ScaledObjectReady`, `KEDAScalersStarted` and `ScaledObjectCheckFailed`.

This is the same regression fixed on the Helm chart side in [kedacore/charts#886](https://github.com/kedacore/charts/pull/886) (and reported in [kedacore/charts#883](https://github.com/kedacore/charts/issues/883)); this PR applies the equivalent fix to the manifests embedded by keda-olm-operator.

### Changes

- `resources/keda.yaml`: restore the core (`""`) API group alongside `events.k8s.io` on the `keda-operator` ClusterRole `events` rule.
- `hack/relprep.sh`: add an idempotent post-download patch so the core group is reapplied on future KEDA version syncs (a no-op once the upstream KEDA release manifest is corrected). `resources/keda.yaml` is downloaded verbatim from the KEDA core release artifact, whose published assets for the affected versions are immutable, so re-running the release-prep script would otherwise silently drop this fix.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))

Fixes #317 