### PR TITLE
feat: support custom KEDA cluster domains

### DIFF
--- a/api/keda/v1alpha1/kedacontroller_types.go
+++ b/api/keda/v1alpha1/kedacontroller_types.go
@@ -39,6 +39,12 @@ type KedaControllerSpec struct {
 	// +optional
 	WatchNamespace string `json:"watchNamespace,omitempty"`
 
+	// ClusterDomain is the Kubernetes cluster DNS domain used for KEDA internal
+	// service communication. When set, it configures both the KEDA operator and
+	// metrics server to use the supplied domain. Leave empty to use KEDA defaults.
+	// +optional
+	ClusterDomain string `json:"clusterDomain,omitempty"`
+
 	// +optional
 	Operator KedaOperatorSpec `json:"operator"`
 

--- a/bundle/manifests/keda.sh_kedacontrollers.yaml
+++ b/bundle/manifests/keda.sh_kedacontrollers.yaml
@@ -3108,6 +3108,12 @@ spec:
                       type: object
                     type: array
                 type: object
+              clusterDomain:
+                description: |-
+                  ClusterDomain is the Kubernetes cluster DNS domain used for KEDA internal
+                  service communication. When set, it configures both the KEDA operator and
+                  metrics server to use the supplied domain. Leave empty to use KEDA defaults.
+                type: string
               httpAddon:
                 description: HTTPAddonSpec defines configuration for the KEDA HTTP
                   Add-on.

--- a/config/crd/bases/keda.sh_kedacontrollers.yaml
+++ b/config/crd/bases/keda.sh_kedacontrollers.yaml
@@ -3105,6 +3105,12 @@ spec:
                       type: object
                     type: array
                 type: object
+              clusterDomain:
+                description: |-
+                  ClusterDomain is the Kubernetes cluster DNS domain used for KEDA internal
+                  service communication. When set, it configures both the KEDA operator and
+                  metrics server to use the supplied domain. Leave empty to use KEDA defaults.
+                type: string
               httpAddon:
                 description: HTTPAddonSpec defines configuration for the KEDA HTTP
                   Add-on.

--- a/config/samples/keda_v1alpha1_kedacontroller.yaml
+++ b/config/samples/keda_v1alpha1_kedacontroller.yaml
@@ -13,6 +13,10 @@ spec:
   # omit or set empty to watch all namespaces (default setting)
   watchNamespace: ""
 
+  ## Kubernetes cluster DNS domain used by KEDA internal service communication.
+  # Leave empty to use KEDA defaults.
+  # clusterDomain: cluster.local
+
   ## KEDA Operator related config
   operator:
     ## Logging level for KEDA Operator

--- a/hack/kedacontroller.yaml
+++ b/hack/kedacontroller.yaml
@@ -13,6 +13,10 @@ spec:
   # omit or set empty to watch all namespaces (default setting)
   watchNamespace: ""
 
+  ## Kubernetes cluster DNS domain used by KEDA internal service communication.
+  # Leave empty to use KEDA defaults.
+  # clusterDomain: cluster.local
+
   ## KEDA Operator related config
   operator:
     ## Logging level for KEDA Operator

--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -709,6 +709,9 @@ func (r *KedaControllerReconciler) installController(ctx context.Context, logger
 		i := i
 		transforms = append(transforms, transform.ReplaceArbitraryArg(instance.Spec.Operator.Args[i], "operator", r.Scheme, logger))
 	}
+	if instance.Spec.ClusterDomain != "" {
+		transforms = append(transforms, transform.ReplaceKedaClusterDomain(instance.Spec.ClusterDomain, r.Scheme, logger))
+	}
 
 	manifest, err := r.resourcesController.Transform(transforms...)
 	if err != nil {
@@ -1229,6 +1232,9 @@ func (r *KedaControllerReconciler) installMetricsServer(ctx context.Context, log
 	for i := range instance.Spec.MetricsServer.Args {
 		i := i
 		transforms = append(transforms, transform.ReplaceArbitraryArg(instance.Spec.MetricsServer.Args[i], "metricsserver", r.Scheme, logger))
+	}
+	if instance.Spec.ClusterDomain != "" {
+		transforms = append(transforms, transform.ReplaceMetricsServiceAddress(instance.Spec.ClusterDomain, instance.Namespace, r.Scheme, logger))
 	}
 
 	// replace namespace in RoleBinding from keda to kube-system

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -37,6 +37,8 @@ const (
 	TLSPrivateKeyFile     Prefix = "--tls-private-key-file="
 	CertRotation          Prefix = "--enable-cert-rotation="
 	CADir                 Prefix = "--ca-dir="
+	KedaClusterDomain     Prefix = "--k8s-cluster-domain="
+	MetricsServiceAddress Prefix = "--metrics-service-address="
 )
 
 func (p Prefix) String() string {
@@ -960,6 +962,19 @@ func ReplaceArbitraryArg(argument string, resource string, scheme *runtime.Schem
 			return nil
 		}
 	}
+}
+
+// ReplaceKedaClusterDomain configures the Kubernetes cluster DNS domain used
+// by the KEDA operator.
+func ReplaceKedaClusterDomain(clusterDomain string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
+	return replaceContainerArg(clusterDomain, KedaClusterDomain, containerNameKedaOperator, scheme, logger)
+}
+
+// ReplaceMetricsServiceAddress configures the metrics server to reach the
+// KEDA operator through the Kubernetes service DNS name.
+func ReplaceMetricsServiceAddress(clusterDomain, namespace string, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {
+	metricsServiceAddress := "keda-operator." + namespace + ".svc." + clusterDomain + ":9666"
+	return replaceContainerArg(metricsServiceAddress, MetricsServiceAddress, containerNameMetricsServer, scheme, logger)
 }
 
 func SetOperatorCertRotation(enable bool, scheme *runtime.Scheme, logger logr.Logger) mf.Transformer {

--- a/internal/controller/keda/transform/transform_test.go
+++ b/internal/controller/keda/transform/transform_test.go
@@ -510,6 +510,61 @@ spec:
 	})
 })
 
+var _ = Describe("Transforming KEDA cluster domain", func() {
+	It("configures the operator and metrics server with the supplied domain", func() {
+		if testType != "unit" {
+			Skip("test.type isn't 'unit'")
+		}
+
+		const yamlData = `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: keda-operator
+          args:
+            - --leader-elect
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-metrics-apiserver
+spec:
+  template:
+    spec:
+      containers:
+        - name: keda-metrics-apiserver
+          args:
+            - --secure-port=6443
+`
+		scheme := runtime.NewScheme()
+		Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+		manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+		Expect(err).To(BeNil())
+
+		updated, err := manifest.Transform(
+			transform.ReplaceKedaClusterDomain("n.internal", scheme, ctrl.Log.WithName("test")),
+			transform.ReplaceMetricsServiceAddress("n.internal", "keda", scheme, ctrl.Log.WithName("test")),
+		)
+		Expect(err).To(BeNil())
+
+		for _, resource := range updated.Resources() {
+			deployment := &appsv1.Deployment{}
+			Expect(scheme.Convert(&resource, deployment, nil)).To(Succeed())
+			switch deployment.Name {
+			case "keda-operator":
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--k8s-cluster-domain=n.internal"))
+			case "keda-metrics-apiserver":
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--metrics-service-address=keda-operator.keda.svc.n.internal:9666"))
+			}
+		}
+	})
+})
+
 // structuredToMap converts a strongly typed volume object to unstructured so we can do a
 // containElement comparison against the unstructured object that comes back from unstructured.NestedSlice
 // and have them actually match


### PR DESCRIPTION
## Summary

Adds `spec.clusterDomain` to `KedaController` for clusters that do not use the default `cluster.local` DNS suffix.

When set, the OLM operator configures:
- KEDA operator: `--k8s-cluster-domain=<domain>`
- KEDA metrics server: `--metrics-service-address=keda-operator.<namespace>.svc.<domain>:9666`

The field is optional; an empty value preserves the existing KEDA defaults.

## Validation

- `make bundle`
- `make test`

### Checklist

- [x] Commit is signed off with DCO

Fixes #