### PR TITLE
feat: provide OpenShift CA certificate to the HTTP Addon

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -454,7 +455,8 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func parseManifestsFromFile(manifest mf.Manifest, c client.Client) (manifestGeneral, manifestController,
-	manifestMetrics, manifestWebhook, manifestMonitoring mf.Manifest, err error) {
+	manifestMetrics, manifestWebhook, manifestMonitoring mf.Manifest, err error,
+) {
 	var generalResources, controllerResources, metricsResources, webhookResources, monitoringResources []unstructured.Unstructured
 
 	for _, r := range manifest.Resources() {
@@ -614,13 +616,7 @@ func (r *KedaControllerReconciler) installController(ctx context.Context, logger
 
 	caConfigMaps := instance.Spec.Operator.CAConfigMaps
 	if runningOnOpenshift {
-		found := false
-		for _, cmName := range caConfigMaps {
-			if cmName == caBundleConfigMapName {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(caConfigMaps, caBundleConfigMapName)
 		if !found {
 			// prepend it
 			caConfigMaps = append([]string{caBundleConfigMapName}, caConfigMaps...)
@@ -962,7 +958,8 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 	globalVersion := instance.Spec.HTTPAddon.Version
 	addonSpec := instance.Spec.HTTPAddon
 
-	removeSeccomp := util.RunningOnOpenshift(ctx, logger, r.Client) && util.RunningOnClusterWithoutSeccompProfileDefault(logger, r.discoveryClient)
+	runningOnOpenshift := util.RunningOnOpenshift(ctx, logger, r.Client)
+	removeSeccomp := runningOnOpenshift && util.RunningOnClusterWithoutSeccompProfileDefault(logger, r.discoveryClient)
 
 	// --- Operator ---
 	operatorImage := ""
@@ -1022,6 +1019,12 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 	)
 	if removeSeccomp {
 		interceptorTransforms = append(interceptorTransforms, transform.RemoveSeccompProfile(httpAddonContainerInterceptor, r.Scheme, logger))
+	}
+
+	// external CAs aren't configurable via the CRD for the HTTP Addon yet, cluster-internal communication is the default
+	if runningOnOpenshift {
+		caConfigMaps := []string{caBundleConfigMapName}
+		interceptorTransforms = append(interceptorTransforms, transform.EnsureCACertsForInterceptorDeployment(caConfigMaps, httpAddonContainerInterceptor, r.Scheme)...)
 	}
 
 	manifest, err = r.resourcesHTTPAddonInterceptor.Transform(interceptorTransforms...)

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -49,6 +49,7 @@ const (
 	containerNameMetricsServer     = "keda-metrics-apiserver"
 	containerNameAdmissionWebhooks = "keda-admission-webhooks"
 	caCertVolPrefix                = "cabundle"
+	httpAddonCACertDirsEnvVar      = "KEDA_HTTP_TLS_CA_DIRS"
 )
 
 // ReplaceAllNamespaces returns a transformer which will traverse the unstructured content looking for map entries with
@@ -619,18 +620,39 @@ func ensureCertificatesVolumeForDeployment(containerName, configMapName, secretN
 	}
 }
 
-// Add configmap volumes for configMapNames named cabundle0, cabundle1, etc. as /custom/ca0, /custom/ca1, etc. with
-// container args --ca-dir=/custom/ca0, --ca-dir=/custom/ca1, etc.
+// EnsureCACertsForOperatorDeployment returns transformers that mount CA certificate ConfigMaps
+// into the operator container and set one --ca-dir arg per mounted ConfigMap.
 func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime.Scheme, logger logr.Logger) []mf.Transformer {
-	var retval []mf.Transformer
-
 	var caDirs []string
 	for i := range configMapNames {
 		caDirs = append(caDirs, "/custom/ca"+strconv.Itoa(i))
 	}
-	retval = append(retval, replaceContainerArgs(caDirs, CADir, containerNameKedaOperator, scheme, logger))
 
-	retval = append(retval, func(u *unstructured.Unstructured) error {
+	return []mf.Transformer{
+		replaceContainerArgs(caDirs, CADir, containerNameKedaOperator, scheme, logger),
+		ensureCACertVolumesAndMounts(configMapNames, containerNameKedaOperator, scheme),
+	}
+}
+
+// EnsureCACertsForInterceptorDeployment returns transformers that mount CA certificate ConfigMaps
+// into the interceptor container and set the CA dirs environment variable.
+func EnsureCACertsForInterceptorDeployment(configMapNames []string, containerName string, scheme *runtime.Scheme) []mf.Transformer {
+	var caDirs []string
+	for i := range configMapNames {
+		caDirs = append(caDirs, "/custom/ca"+strconv.Itoa(i))
+	}
+	caDirsEnvVar := corev1.EnvVar{Name: httpAddonCACertDirsEnvVar, Value: strings.Join(caDirs, ",")}
+
+	return []mf.Transformer{
+		ReplaceContainerEnv([]corev1.EnvVar{caDirsEnvVar}, containerName, scheme),
+		ensureCACertVolumesAndMounts(configMapNames, containerName, scheme),
+	}
+}
+
+// ensureCACertVolumesAndMounts mounts configMapNames on containerName as indexed cabundle
+// volumes at /custom/ca<N>, replacing any stale cabundle volumes/mounts.
+func ensureCACertVolumesAndMounts(configMapNames []string, containerName string, scheme *runtime.Scheme) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" {
 			deploy := &appsv1.Deployment{}
 			if err := scheme.Convert(u, deploy, nil); err != nil {
@@ -678,7 +700,7 @@ func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime
 
 			containers := deploy.Spec.Template.Spec.Containers
 			for i := range containers {
-				if containers[i].Name == containerNameKedaOperator {
+				if containers[i].Name == containerName {
 					// mount Volumes referencing certs in ConfigMap
 					var volumeMounts []corev1.VolumeMount
 					cabundleVolumeMountFound := map[string]bool{}
@@ -705,8 +727,7 @@ func EnsureCACertsForOperatorDeployment(configMapNames []string, scheme *runtime
 			}
 		}
 		return nil
-	})
-	return retval
+	}
 }
 
 func EnsurePathsToCertsInDeployment(values []string, prefixes []Prefix, scheme *runtime.Scheme, logger logr.Logger) []mf.Transformer {

--- a/internal/controller/keda/transform/transform_test.go
+++ b/internal/controller/keda/transform/transform_test.go
@@ -510,6 +510,160 @@ spec:
 	})
 })
 
+var _ = Describe("Transforming operator deployment for CA certs", func() {
+	Context("When transforming a KEDA operator Deployment", func() {
+
+		scheme := runtime.NewScheme()
+		_ = appsv1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+
+		logger := ctrl.Log.WithName("test")
+
+		yamlData := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda-operator
+  template:
+    metadata:
+      labels:
+        app: keda-operator
+    spec:
+      containers:
+        - name: keda-operator
+          image: keda:latest
+          volumeMounts:
+            - name: example-volume
+              mountPath: /example
+      volumes:
+        - name: example-volume
+          configMap:
+            name: example`
+
+		It("Should replace stale CA bundle args/volumes/mounts when the config map list changes", func() {
+			manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+			Expect(err).To(BeNil())
+
+			By("Reconciling with a single config map")
+			firstTransforms := transform.EnsureCACertsForOperatorDeployment([]string{"corporate-ca-0"}, scheme, logger)
+			manifest, err = manifest.Transform(firstTransforms...)
+			Expect(err).To(BeNil())
+
+			By("Reconciling again with two different config maps")
+			secondTransforms := transform.EnsureCACertsForOperatorDeployment([]string{"corporate-ca-1", "corporate-ca-2"}, scheme, logger)
+			newManifest, err := manifest.Transform(secondTransforms...)
+			Expect(err).To(BeNil())
+
+			r := newManifest.Resources()
+			Expect(len(r)).To(Equal(1))
+
+			By("Checking only the new CA bundle volumes are present")
+			volumes, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "volumes")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			expectCABundleVolumes(volumes)
+
+			By("Checking the operator container has the new --ca-dir args and the CA bundle mounts")
+			containers, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "containers")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+
+			args, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "args")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			Expect(args).To(ConsistOf("--ca-dir=/custom/ca0", "--ca-dir=/custom/ca1"))
+
+			volumeMounts, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "volumeMounts")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			expectCABundleVolumeMounts(volumeMounts)
+		})
+	})
+})
+
+var _ = Describe("Transforming interceptor deployment for CA certs", func() {
+	Context("When transforming an HTTP Add-on interceptor Deployment", func() {
+
+		scheme := runtime.NewScheme()
+		_ = appsv1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+
+		yamlData := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-add-ons-http-interceptor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda-add-ons-http-interceptor
+  template:
+    metadata:
+      labels:
+        app: keda-add-ons-http-interceptor
+    spec:
+      containers:
+        - name: interceptor
+          image: interceptor:latest
+          env:
+            - name: KEDA_HTTP_PROXY_PORT
+              value: "8080"
+          volumeMounts:
+            - name: example-volume
+              mountPath: /example
+      volumes:
+        - name: example-volume
+          configMap:
+            name: example`
+
+		It("Should replace stale CA bundle volumes, mounts, and env var when the config map list changes", func() {
+			manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(yamlData)))
+			Expect(err).To(BeNil())
+
+			By("Reconciling with a single config map")
+			firstTransforms := transform.EnsureCACertsForInterceptorDeployment([]string{"corporate-ca-0"}, "interceptor", scheme)
+			manifest, err = manifest.Transform(firstTransforms...)
+			Expect(err).To(BeNil())
+
+			By("Reconciling again with two different config maps")
+			secondTransforms := transform.EnsureCACertsForInterceptorDeployment([]string{"corporate-ca-1", "corporate-ca-2"}, "interceptor", scheme)
+			newManifest, err := manifest.Transform(secondTransforms...)
+			Expect(err).To(BeNil())
+
+			r := newManifest.Resources()
+			Expect(len(r)).To(Equal(1))
+
+			By("Checking only the new CA bundle volumes are present")
+			volumes, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "volumes")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			expectCABundleVolumes(volumes)
+
+			By("Checking the interceptor container has the new CA bundle mounts and env var")
+			containers, found, err := unstructured.NestedSlice(r[0].UnstructuredContent(), "spec", "template", "spec", "containers")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+
+			volumeMounts, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "volumeMounts")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			expectCABundleVolumeMounts(volumeMounts)
+
+			env, found, err := unstructured.NestedSlice(structuredToMap(containers[0]), "env")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			Expect(env).To(ContainElement(structuredToMap(corev1.EnvVar{Name: "KEDA_HTTP_TLS_CA_DIRS", Value: "/custom/ca0,/custom/ca1"})))
+			Expect(env).To(ContainElement(structuredToMap(corev1.EnvVar{Name: "KEDA_HTTP_PROXY_PORT", Value: "8080"})))
+		})
+	})
+})
+
 // structuredToMap converts a strongly typed volume object to unstructured so we can do a
 // containElement comparison against the unstructured object that comes back from unstructured.NestedSlice
 // and have them actually match
@@ -519,4 +673,31 @@ func structuredToMap(thing interface{}) map[string]interface{} {
 		panic(err)
 	}
 	return objMap
+}
+
+// expectCABundleVolumes asserts that volumes contains only the cabundle0/cabundle1 volumes for
+// corporate-ca-1/corporate-ca-2 and the pre-existing example-volume.
+func expectCABundleVolumes(volumes []interface{}) {
+	Expect(volumes).To(HaveLen(3), "example-volume + 2 new cabundle volumes, stale one replaced")
+	Expect(volumes).To(ContainElement(structuredToMap(corev1.Volume{
+		Name:         "cabundle0",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "corporate-ca-1"}}},
+	})))
+	Expect(volumes).To(ContainElement(structuredToMap(corev1.Volume{
+		Name:         "cabundle1",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "corporate-ca-2"}}},
+	})))
+	Expect(volumes).To(ContainElement(structuredToMap(corev1.Volume{
+		Name:         "example-volume",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "example"}}},
+	})))
+}
+
+// expectCABundleVolumeMounts asserts that volumeMounts contains only the cabundle0/cabundle1 mounts
+// and the pre-existing example-volume mount.
+func expectCABundleVolumeMounts(volumeMounts []interface{}) {
+	Expect(volumeMounts).To(HaveLen(3))
+	Expect(volumeMounts).To(ContainElement(structuredToMap(corev1.VolumeMount{Name: "cabundle0", MountPath: "/custom/ca0"})))
+	Expect(volumeMounts).To(ContainElement(structuredToMap(corev1.VolumeMount{Name: "cabundle1", MountPath: "/custom/ca1"})))
+	Expect(volumeMounts).To(ContainElement(structuredToMap(corev1.VolumeMount{Name: "example-volume", MountPath: "/example"})))
 }


### PR DESCRIPTION
The upstream HTTP Add-on now supports trusting custom CAs similar to the KEDA operator.
On OpenShift, mount the same keda-ocp-cabundle ConfigMap the operator path already trusts. External CAs from spec.operator.caConfigMaps are not wired into the interceptor — that field only affects the KEDA operator; cluster-internal communication is the default for the interceptor and there's no CRD field to configure external CAs for it yet.


Will create a followup PR for unrelated changes from `go fix ./...` 

I tested this in a CRC cluster, interceptor deployment was updated and logs also showed that the CA bundle was configured. I didn't go further to test the connection to a backend serving using that as this was done in the HTTP Addons e2e tests as part of https://github.com/kedacore/http-add-on/pull/1731 .

### Changes
- Add EnsureCACertsForInterceptorDeployment for the env var + cabundle volume/mount wiring on the interceptor container
- Pull the volume/mount logic out of EnsureCACertsForOperatorDeployment into a shared helper (operator behavior unchanged)
- Wire it into installHTTPAddon: only mounted when running on OpenShift


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
