### PR TITLE
feat: wire OpenShift TLS for HTTP add-on interceptor

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -91,6 +91,10 @@ const (
 
 	kedaTLSCipherListEnvVar = "KEDA_SERVICE_TLS_CIPHER_LIST"
 	kedaTLSMinVersionEnvVar = "KEDA_SERVICE_MIN_TLS_VERSION"
+
+	httpAddonProxyTLSEnabledEnvVar = "KEDA_HTTP_PROXY_TLS_ENABLED"
+	httpAddonTLSCipherSuitesEnvVar = "KEDA_HTTP_TLS_CIPHER_SUITES"
+	httpAddonTLSMinVersionEnvVar   = "KEDA_HTTP_TLS_MIN_VERSION"
 )
 
 // KedaControllerReconciler reconciles a KedaController object
@@ -284,35 +288,52 @@ func (r *KedaControllerReconciler) enqueueOnTLSProfileChange(oldObj, newObj clie
 	r.enqueueKedaControllerReconcile(q)
 }
 
-// tlsEnvVarTransforms reads the current TLS profile from the APIServer via the manager cache and
-// returns Transformers that set KEDA_SERVICE_TLS_CIPHER_LIST and KEDA_SERVICE_MIN_TLS_VERSION in
-// all containers of all Deployment resources. Returns nil if the fetch fails or if the TLS
-// adherence policy does not require honoring the cluster-wide profile (in which case KEDA uses its
-// own defaults).
-func (r *KedaControllerReconciler) tlsEnvVarTransforms(ctx context.Context, logger logr.Logger) []mf.Transformer {
+// kedaTLSEnvVarTransforms sets KEDA's TLS env vars from the cluster TLS profile, or nil if unavailable.
+func (r *KedaControllerReconciler) kedaTLSEnvVarTransforms(ctx context.Context, logger logr.Logger) []mf.Transformer {
+	minTLSVersion, cipherList, ok := r.clusterTLSProfile(ctx, logger)
+	if !ok {
+		return nil
+	}
+	return []mf.Transformer{
+		transform.EnsureEnvVarInAllContainers(kedaTLSMinVersionEnvVar, minTLSVersion, r.Scheme),
+		transform.EnsureEnvVarInAllContainers(kedaTLSCipherListEnvVar, cipherList, r.Scheme),
+	}
+}
+
+// httpAddonTLSEnvVarTransforms sets HTTP add-on TLS env vars from the cluster TLS profile, or nil if unavailable.
+func (r *KedaControllerReconciler) httpAddonTLSEnvVarTransforms(ctx context.Context, logger logr.Logger) []mf.Transformer {
+	minTLSVersion, cipherList, ok := r.clusterTLSProfile(ctx, logger)
+	if !ok {
+		return nil
+	}
+	return []mf.Transformer{
+		transform.EnsureEnvVarInAllContainers(httpAddonTLSMinVersionEnvVar, minTLSVersion, r.Scheme),
+		transform.EnsureEnvVarInAllContainers(httpAddonTLSCipherSuitesEnvVar, cipherList, r.Scheme),
+	}
+}
+
+// clusterTLSProfile fetches the OpenShift cluster TLS profile; ok is false if unavailable or not required.
+func (r *KedaControllerReconciler) clusterTLSProfile(ctx context.Context, logger logr.Logger) (minTLSVersion, cipherList string, ok bool) {
 	apiServer := &openshiftconfigv1.APIServer{}
 	if err := r.Get(ctx, client.ObjectKey{Name: tlspkg.APIServerName}, apiServer); err != nil {
 		logger.Error(err, "Failed to fetch APIServer; skipping TLS env var update")
-		return nil
+		return "", "", false
 	}
 	if !libgocrypto.ShouldHonorClusterTLSProfile(apiServer.Spec.TLSAdherence) {
 		logger.V(4).Info("TLS adherence policy does not require honoring cluster TLS profile; skipping TLS env var injection", "policy", apiServer.Spec.TLSAdherence)
-		return nil
+		return "", "", false
 	}
 	profile, err := tlspkg.GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
 	if err != nil {
 		logger.Error(err, "Failed to get TLS profile from APIServer; skipping TLS env var update")
-		return nil
+		return "", "", false
 	}
-	minTLSVersion, ianaCiphers := util.ConvertTLSProfileSpec(profile)
+	minVer, ianaCiphers := util.ConvertTLSProfileSpec(profile)
 	if len(ianaCiphers) != len(profile.Ciphers) {
 		logger.Info("Some TLS profile ciphers could not be converted to IANA names and were dropped",
 			"requested", profile.Ciphers, "converted", ianaCiphers)
 	}
-	return []mf.Transformer{
-		transform.EnsureEnvVarInAllContainers(kedaTLSMinVersionEnvVar, minTLSVersion, r.Scheme),
-		transform.EnsureEnvVarInAllContainers(kedaTLSCipherListEnvVar, strings.Join(ianaCiphers, ","), r.Scheme),
-	}
+	return minVer, strings.Join(ianaCiphers, ","), true
 }
 
 // +kubebuilder:rbac:groups=keda.sh,resources=kedacontrollers;kedacontrollers/finalizers;kedacontrollers/status,verbs="*"
@@ -611,7 +632,7 @@ func (r *KedaControllerReconciler) installController(ctx context.Context, logger
 	runningOnOpenshift := util.RunningOnOpenshift(ctx, logger, r.Client)
 
 	if r.injectTLSEnvVars {
-		transforms = append(transforms, r.tlsEnvVarTransforms(ctx, logger)...)
+		transforms = append(transforms, r.kedaTLSEnvVarTransforms(ctx, logger)...)
 	}
 
 	caConfigMaps := instance.Spec.Operator.CAConfigMaps
@@ -1020,6 +1041,18 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 	if removeSeccomp {
 		interceptorTransforms = append(interceptorTransforms, transform.RemoveSeccompProfile(httpAddonContainerInterceptor, r.Scheme, logger))
 	}
+	if runningOnOpenshift {
+		interceptorService := "keda-add-ons-http-interceptor-proxy"
+		interceptorCertsSecret := interceptorService + "-certs"
+		interceptorTransforms = append(interceptorTransforms,
+			transform.EnsureCertInjectionForService(interceptorService, servingCertsAnnotation, interceptorCertsSecret),
+			transform.EnsureCertSecretVolume(httpAddonContainerInterceptor, interceptorCertsSecret, r.Scheme),
+			transform.EnsureEnvVarInAllContainers(httpAddonProxyTLSEnabledEnvVar, "true", r.Scheme),
+		)
+		if r.injectTLSEnvVars {
+			interceptorTransforms = append(interceptorTransforms, r.httpAddonTLSEnvVarTransforms(ctx, logger)...)
+		}
+	}
 
 	// external CAs aren't configurable via the CRD for the HTTP Addon yet, cluster-internal communication is the default
 	if runningOnOpenshift {
@@ -1102,7 +1135,7 @@ func (r *KedaControllerReconciler) installMetricsServer(ctx context.Context, log
 	}
 
 	if r.injectTLSEnvVars {
-		transforms = append(transforms, r.tlsEnvVarTransforms(ctx, logger)...)
+		transforms = append(transforms, r.kedaTLSEnvVarTransforms(ctx, logger)...)
 	}
 
 	// on OpenShift 4.10 (kube 1.23) and earlier, the RuntimeDefault SeccompProfile won't validate against any SCC
@@ -1392,7 +1425,7 @@ func (r *KedaControllerReconciler) installAdmissionWebhooks(ctx context.Context,
 	}
 
 	if r.injectTLSEnvVars {
-		transforms = append(transforms, r.tlsEnvVarTransforms(ctx, logger)...)
+		transforms = append(transforms, r.kedaTLSEnvVarTransforms(ctx, logger)...)
 	}
 
 	// on OpenShift 4.10 (kube 1.23) and earlier, the RuntimeDefault SeccompProfile won't validate against any SCC

--- a/internal/controller/keda/transform/transform.go
+++ b/internal/controller/keda/transform/transform.go
@@ -1641,6 +1641,61 @@ func ReplaceLogTimeEncoding(logTimeEncoding string, containerName string, scheme
 	return replaceContainerArg(logTimeEncoding, LogTimeEncodingArg, containerName, scheme, logger)
 }
 
+// EnsureCertSecretVolume returns a Transformer that mounts the named Secret as a volume
+// at /certs (read-only) in the specified container of all Deployment resources.
+func EnsureCertSecretVolume(containerName, secretName string, scheme *runtime.Scheme) mf.Transformer {
+	volumeName := containerName + "-certs"
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Deployment" {
+			return nil
+		}
+		deploy := &appsv1.Deployment{}
+		if err := scheme.Convert(u, deploy, nil); err != nil {
+			return err
+		}
+
+		vol := corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: secretName},
+			},
+		}
+		replaced := false
+		for i, v := range deploy.Spec.Template.Spec.Volumes {
+			if v.Name == volumeName {
+				deploy.Spec.Template.Spec.Volumes[i] = vol
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, vol)
+		}
+
+		mount := corev1.VolumeMount{Name: volumeName, MountPath: "/certs", ReadOnly: true}
+		for i := range deploy.Spec.Template.Spec.Containers {
+			c := &deploy.Spec.Template.Spec.Containers[i]
+			if c.Name != containerName {
+				continue
+			}
+			mountReplaced := false
+			for j, m := range c.VolumeMounts {
+				if m.Name == volumeName {
+					c.VolumeMounts[j] = mount
+					mountReplaced = true
+					break
+				}
+			}
+			if !mountReplaced {
+				c.VolumeMounts = append(c.VolumeMounts, mount)
+			}
+			break
+		}
+
+		return scheme.Convert(deploy, u, nil)
+	}
+}
+
 // EnsureEnvVarInAllContainers returns a Transformer that ensures an environment variable
 // with the given name is set to the given value in all containers of all Deployment resources.
 func EnsureEnvVarInAllContainers(name, value string, scheme *runtime.Scheme) mf.Transformer {

--- a/internal/controller/keda/transform/transform_test.go
+++ b/internal/controller/keda/transform/transform_test.go
@@ -664,6 +664,90 @@ spec:
 	})
 })
 
+var _ = Describe("EnsureCertSecretVolume", func() {
+	BeforeEach(func() {
+		if testType != "unit" {
+			Skip("test.type isn't 'unit'")
+		}
+	})
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	deployYAML := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - name: main
+          image: main:latest
+        - name: sidecar
+          image: sidecar:latest`
+
+	It("should add volume and mount to the target container and update idempotently", func() {
+		manifest, err := mf.ManifestFrom(mf.Reader(strings.NewReader(deployYAML)))
+		Expect(err).To(BeNil())
+
+		newManifest, err := manifest.Transform(
+			transform.EnsureCertSecretVolume("main", "my-certs-secret", scheme),
+		)
+		Expect(err).To(BeNil())
+
+		deploy := &appsv1.Deployment{}
+		Expect(scheme.Convert(&newManifest.Resources()[0], deploy, nil)).To(Succeed())
+
+		Expect(deploy.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
+			Name: "main-certs",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "my-certs-secret"},
+			},
+		}))
+
+		main := deploy.Spec.Template.Spec.Containers[0]
+		Expect(main.VolumeMounts).To(ContainElement(corev1.VolumeMount{
+			Name: "main-certs", MountPath: "/certs", ReadOnly: true,
+		}))
+
+		sidecar := deploy.Spec.Template.Spec.Containers[1]
+		Expect(sidecar.VolumeMounts).To(BeEmpty())
+
+		// Apply again with a different secret — should replace, not duplicate.
+		updatedManifest, err := newManifest.Transform(
+			transform.EnsureCertSecretVolume("main", "updated-secret", scheme),
+		)
+		Expect(err).To(BeNil())
+
+		updatedDeploy := &appsv1.Deployment{}
+		Expect(scheme.Convert(&updatedManifest.Resources()[0], updatedDeploy, nil)).To(Succeed())
+
+		Expect(updatedDeploy.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(updatedDeploy.Spec.Template.Spec.Volumes[0]).To(Equal(corev1.Volume{
+			Name: "main-certs",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "updated-secret"},
+			},
+		}))
+
+		updatedMain := updatedDeploy.Spec.Template.Spec.Containers[0]
+		Expect(updatedMain.VolumeMounts).To(HaveLen(1))
+		Expect(updatedMain.VolumeMounts[0]).To(Equal(corev1.VolumeMount{
+			Name: "main-certs", MountPath: "/certs", ReadOnly: true,
+		}))
+	})
+})
+
 // structuredToMap converts a strongly typed volume object to unstructured so we can do a
 // containElement comparison against the unstructured object that comes back from unstructured.NestedSlice
 // and have them actually match


### PR DESCRIPTION
On OpenShift, the interceptor proxy Service now gets a serving cert via service-ca-operator, and the interceptor Deployment mounts it at /certs. The cluster-wide TLS profile (min version, cipher suites) is injected when the APIServer TLS adherence policy requires it.

### Changes
- Add EnsureCertSecretVolume transform (Secret volume + mount on a named container)
- Add httpAddonTLSEnvVarTransforms to inject KEDA_HTTP_TLS_* env vars from the OpenShift APIServer TLS profile
- Extract clusterTLSProfile helper from tlsEnvVarTransforms to share APIServer fetch logic
- Wire cert annotation, volume, and env vars in installHTTPAddon()
- Add unit tests for EnsureCertSecretVolume

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
