### PR TITLE
fix: correct createdAt, CRD sync and version pinning in relprep.sh

### DIFF
--- a/hack/relprep.sh
+++ b/hack/relprep.sh
@@ -95,7 +95,7 @@ sed -i 's/\(app.kubernetes.io\/version:\) [0-9.][0-9.]*/\1 '${ver}/ keda/${ver}/
 
 date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 echo "Updating all version strings, 'replaces' and 'createdAt' fields in base CSV"
-sed -i "s/${prev//./\\.}/${ver}/; s/^\\(  replaces: *keda.v\\)[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/\1${prev}/; s/\\(  *createdAt: *\\)\"?[0-9-]*T[0-9:.]*Z\"/\1\"${date}\"/" config/manifests/bases/keda.clusterserviceversion.yaml
+sed -i "s/${prev//./\\.}/${ver}/; s/^\\(  replaces: *keda.v\\)[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/\1${prev}/; s/^\\(  *createdAt: *\\).*\$/\1\"${date}\"/" config/manifests/bases/keda.clusterserviceversion.yaml
 
 rm -f keda/${ver}/manifests/keda.v${prev}.clusterserviceversion.yaml
 echo "Creating release CSV keda.v${ver}.clusterserviceversion.yaml"
@@ -123,9 +123,27 @@ all_mods="$(go list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}
 declare -A updated_mods
 to_update=()
 
-# force versions of k8s components
+# Treat KEDA's version as a floor rather than an exact pin. The OpenShift
+# modules we depend on (openshift/{api,library-go,controller-runtime-common})
+# track newer k8s.io and controller-runtime releases than KEDA pins, and asking
+# 'go get' to downgrade below them makes it fail outright.
+floor_version() {
+  local mod=$1 want=$2 cur
+  if ! cur=$(go list -mod=readonly -m -f '{{.Version}}' "$mod" 2>/dev/null) || [ -z "$cur" ]; then
+    echo "$want"
+    return
+  fi
+  if [ "$(printf '%s\n%s\n' "$want" "$cur" | sort -V | tail -1)" = "$want" ]; then
+    echo "$want"
+  else
+    echo "  keeping $mod at $cur, newer than KEDA's $want (required by other dependencies)" >&2
+    echo "$cur"
+  fi
+}
+
+# match versions of k8s components used by KEDA
 for i in $kube_components; do
-    to_update+=("k8s.io/$i@$k8sver")
+    to_update+=("k8s.io/$i@$(floor_version "k8s.io/$i" "$k8sver")")
     updated_mods["k8s.io/$i"]=1
 done
 
@@ -136,7 +154,7 @@ for i in $match_keda_version_deps; do
       exit 1
     fi
     echo "  got version $modver"
-    to_update+=("$i@$modver")
+    to_update+=("$i@$(floor_version "$i" "$modver")")
     updated_mods["$i"]=1
 done
 
@@ -172,6 +190,18 @@ make manifests
 cp config/crd/bases/keda.sh_kedacontrollers.yaml keda/${ver}/manifests/
 # revert any changes to the kustomization
 git checkout config/manager/kustomization.yaml config/default/kustomization.yaml
+
+echo "Syncing any remaining CRDs in keda/${ver}/manifests/ from config/crd/bases/"
+# CRDs that do not come from resources/keda.yaml (currently the HTTP Add-on's,
+# maintained by hack/http-add-on-relprep.sh) are inherited verbatim from the
+# previous release directory, so without this they ship a stale schema.
+for f in keda/${ver}/manifests/*.yaml; do
+  crdbase="config/crd/bases/$(basename "$f")"
+  if [ -f "$crdbase" ] && ! cmp -s "$crdbase" "$f"; then
+    echo " $(basename "$f")"
+    cp "$crdbase" "$f"
+  fi
+done
 
 echo "Syncing bundle annotations to keda/${ver}/metadata/ (stripping test-only entries)"
 sed '/operators\.operatorframework\.io\.test\./d; /^[[:space:]]*#/d; /^[[:space:]]*$/d' \


### PR DESCRIPTION
Three problems in `hack/relprep.sh` surfaced while preparing the 2.20.2 release (#337), where each had to be worked around by hand.

### `createdAt` was never updated

The substitution used `\"?` in a *basic* regex, where `?` is a literal character rather than a quantifier, so it never matched and the CSV kept the previous release's timestamp. This is long-standing: 2.19.0 shipped with a `2023-09-11` timestamp. Now matches the rest of the line instead.

### HTTP Add-on CRDs went stale in the bundle

A new release directory is copied verbatim from the previous one, and only CRDs found in `resources/keda.yaml` are refreshed afterwards. The HTTP Add-on's CRDs are maintained separately by `hack/http-add-on-relprep.sh`, so they were never updated — the 2.20.2 bundle carried the `InterceptorRoute` schema from add-on 0.14.0 while shipping 0.15.0.

Every bundle CRD that has a `config/crd/bases` counterpart is now synced, which keeps the two in step regardless of where a given CRD comes from.

### Exact version pins made `go get` fail

`k8s.io/*` and `controller-runtime` were pinned to KEDA's exact versions. The OpenShift modules we depend on (`openshift/{api,library-go,controller-runtime-common}`) require newer releases than KEDA pins, so the script aborted rather than resolving:

```
go: github.com/openshift/api@release-4.23 requires k8s.io/api@v0.36.2, not k8s.io/api@v0.36.0
go: github.com/openshift/controller-runtime-common@upgrade requires sigs.k8s.io/controller-runtime@v0.24.1, not sigs.k8s.io/controller-runtime@v0.23.3
```

KEDA's version is now treated as a floor: it still upgrades when KEDA moves ahead, but never downgrades below what the rest of the module graph requires, and it reports each version it keeps. This matches what 2.20.1 actually shipped.

### Testing

- `bash -n` passes.
- `createdAt` substitution verified against the real base CSV, including that it is idempotent and touches only the one line, while `replaces` and `version` still update correctly.
- CRD sync verified against a scratch copy of the 2.20.1 bundle: it refreshes the stale `InterceptorRoute`, leaves the CSV alone, and is idempotent.
- `floor_version` verified for the older / newer / equal / unknown-module cases, and the previously failing `go get -u` now completes successfully.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release preparation to keep generated release manifests synchronized with their source definitions.
  - Updated release metadata handling to apply consistent creation timestamps.
  - Improved dependency version handling to preserve newer resolved versions while applying required minimum versions when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->