### PR TITLE
chore: add operator-sdk prerequisite to bundle-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE) .
 
 .PHONY: bundle-push
-bundle-push:
+bundle-push: operator-sdk
 	docker push ${BUNDLE}
 	$(OPERATOR_SDK) bundle validate ${BUNDLE}
 


### PR DESCRIPTION
Ensure clean checkouts acquire the local operator-sdk before bundle validation runs after the image push.

Found in https://github.com/openshift/custom-metrics-autoscaler-operator/pull/104#discussion_r3922858077

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bundle publishing now verifies the required operator tooling is available before pushing and validating bundle images.
  - This improves the reliability and consistency of the bundle release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->