### PR TITLE
fix: transform operand manifests from pristine copies

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -98,6 +98,11 @@ const (
 )
 
 // KedaControllerReconciler reconciles a KedaController object
+//
+// The resources* manifests hold the operands exactly as loaded from disk at start-up
+// and must stay that way. Every reconcile renders them through the spec-driven
+// transformers, which can only add or overwrite entries, never remove them, so storing
+// a rendered manifest back would keep applying spec values the user has since deleted.
 type KedaControllerReconciler struct {
 	client.Client
 	Log                           logr.Logger
@@ -388,7 +393,7 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			// Run finalization logic for kedaControllerFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			if err := r.finalizeKedaController(logger); err != nil {
+			if err := r.finalizeKedaController(logger, instance); err != nil {
 				return ctrl.Result{}, err
 			}
 			// Remove kedaControllerFinalizer. Once all finalizers have been
@@ -602,11 +607,10 @@ func (r *KedaControllerReconciler) installGeneralResources(ctx context.Context, 
 		logger.Error(err, "Unable to transform ServiceAccount and NetworkPolicies manifests")
 		return err
 	}
-	r.resourcesGeneral = manifest
 
 	isEmptyKedaAllowEgressToAllNetworkPolicy := getIsEmptyKedaAllowEgressToAllNetworkPolicyPredicate(r.Scheme)
-	toDelete := r.resourcesGeneral.Filter(isEmptyKedaAllowEgressToAllNetworkPolicy)
-	toApply := r.resourcesGeneral.Filter(mf.Not(isEmptyKedaAllowEgressToAllNetworkPolicy))
+	toDelete := manifest.Filter(isEmptyKedaAllowEgressToAllNetworkPolicy)
+	toApply := manifest.Filter(mf.Not(isEmptyKedaAllowEgressToAllNetworkPolicy))
 
 	if err := toDelete.Delete(); err != nil {
 		logger.Error(err, "Unable to delete unwanted NetworkPolicy keda-allow-egress-to-all")
@@ -740,9 +744,8 @@ func (r *KedaControllerReconciler) installController(ctx context.Context, logger
 		logger.Error(err, "Unable to transform KEDA Controller manifest")
 		return err
 	}
-	r.resourcesController = manifest
 
-	if err := r.resourcesController.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install KEDA Controller")
 		return err
 	}
@@ -796,9 +799,8 @@ func (r *KedaControllerReconciler) installMonitoring(ctx context.Context, logger
 		logger.Error(err, "Unable to transform monitoring resource manifests")
 		return err
 	}
-	r.resourcesMonitoring = manifest
 
-	if err := r.resourcesMonitoring.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install monitoring resources")
 		return err
 	}
@@ -845,25 +847,41 @@ func (r *KedaControllerReconciler) parseHTTPAddonManifests(manifest mf.Manifest)
 	return nil
 }
 
-func deleteHTTPAddonManifest(logger logr.Logger, manifest mf.Manifest, component string) error {
+// renderForDelete points an untransformed operand manifest at the objects that were
+// actually installed. Deletion only needs to match each resource by kind, name and
+// namespace, so the namespace rewriting is enough and the spec-driven transforms that
+// shape the object bodies can be skipped.
+//
+// Any install transform that changes a resource's kind, name or namespace has to be
+// mirrored here through extra, or the affected object will be left behind on delete.
+func renderForDelete(manifest mf.Manifest, namespace string, extra ...mf.Transformer) (mf.Manifest, error) {
+	return manifest.Transform(append([]mf.Transformer{transform.ReplaceAllNamespaces(namespace)}, extra...)...)
+}
+
+func deleteHTTPAddonManifest(logger logr.Logger, manifest mf.Manifest, namespace string, component string) error {
 	if manifest.Client == nil && len(manifest.Resources()) == 0 {
 		return nil
 	}
-	if err := manifest.Delete(); err != nil {
+	rendered, err := renderForDelete(manifest, namespace)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("Unable to transform HTTP Add-on %s manifest for deletion", component))
+		return err
+	}
+	if err := rendered.Delete(); err != nil {
 		logger.Error(err, fmt.Sprintf("Unable to delete HTTP Add-on %s resources", component))
 		return err
 	}
 	return nil
 }
 
-func (r *KedaControllerReconciler) deleteHTTPAddon(logger logr.Logger) error {
-	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonScaler, "Scaler"); err != nil {
+func (r *KedaControllerReconciler) deleteHTTPAddon(logger logr.Logger, namespace string) error {
+	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonScaler, namespace, "Scaler"); err != nil {
 		return err
 	}
-	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonInterceptor, "Interceptor"); err != nil {
+	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonInterceptor, namespace, "Interceptor"); err != nil {
 		return err
 	}
-	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonOperator, "Operator"); err != nil {
+	if err := deleteHTTPAddonManifest(logger, r.resourcesHTTPAddonOperator, namespace, "Operator"); err != nil {
 		return err
 	}
 	return nil
@@ -966,7 +984,7 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 	if !instance.Spec.HTTPAddon.Enabled {
 		if status.HTTPAddon != nil {
 			logger.Info("HTTP Add-on is disabled, cleaning up resources")
-			if err := r.deleteHTTPAddon(logger); err != nil {
+			if err := r.deleteHTTPAddon(logger, instance.Namespace); err != nil {
 				return err
 			}
 			status.HTTPAddon = nil
@@ -1016,9 +1034,8 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 		status.HTTPAddon = httpAddonStatus
 		return err
 	}
-	r.resourcesHTTPAddonOperator = manifest
 
-	if err := r.resourcesHTTPAddonOperator.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install HTTP Add-on Operator")
 		httpAddonStatus.MarkInstallFailed("Failed to install HTTP Add-on Operator")
 		status.HTTPAddon = httpAddonStatus
@@ -1072,9 +1089,8 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 		status.HTTPAddon = httpAddonStatus
 		return err
 	}
-	r.resourcesHTTPAddonInterceptor = manifest
 
-	if err := r.resourcesHTTPAddonInterceptor.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install HTTP Add-on Interceptor")
 		httpAddonStatus.MarkInstallFailed("Failed to install HTTP Add-on Interceptor")
 		status.HTTPAddon = httpAddonStatus
@@ -1110,9 +1126,8 @@ func (r *KedaControllerReconciler) installHTTPAddon(ctx context.Context, logger 
 		status.HTTPAddon = httpAddonStatus
 		return err
 	}
-	r.resourcesHTTPAddonScaler = manifest
 
-	if err := r.resourcesHTTPAddonScaler.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install HTTP Add-on Scaler")
 		httpAddonStatus.MarkInstallFailed("Failed to install HTTP Add-on Scaler")
 		status.HTTPAddon = httpAddonStatus
@@ -1288,9 +1303,8 @@ func (r *KedaControllerReconciler) installMetricsServer(ctx context.Context, log
 		logger.Error(err, "Unable to transform Metrics Server manifest")
 		return err
 	}
-	r.resourcesMetrics = manifest
 
-	if err := r.resourcesMetrics.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install Metrics Server")
 		return err
 	}
@@ -1530,9 +1544,8 @@ func (r *KedaControllerReconciler) installAdmissionWebhooks(ctx context.Context,
 		logger.Error(err, "Unable to transform KEDA Admission Webhooks manifest")
 		return err
 	}
-	r.resourcesWebhooks = manifest
 
-	if err := r.resourcesWebhooks.Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		logger.Error(err, "Unable to install KEDA Admission Webhooks")
 		return err
 	}

--- a/internal/controller/keda/kedacontroller_controller_test.go
+++ b/internal/controller/keda/kedacontroller_controller_test.go
@@ -363,7 +363,7 @@ var _ = Describe("Testing functionality", func() {
 		})
 	})
 
-	var _ = Describe("Setting component environment variables", func() {
+	var _ = Describe("Setting and removing component environment variables", func() {
 
 		const (
 			kind                 = "KedaController"
@@ -385,9 +385,30 @@ var _ = Describe("Testing functionality", func() {
 		BeforeEach(func() {
 			scheme = k8sManager.GetScheme()
 			dep = &appsv1.Deployment{}
+
+			// The operator creates a default KedaController at start-up. Wait for it to reach the
+			// client cache, otherwise Apply races it and tries to create a second one.
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: namespace, Namespace: namespace}, &kedav1alpha1.KedaController{})
+			}, timeout, interval).Should(Succeed())
+
 			manifest, err = createManifest(kedaManifestFilepath, k8sClient)
 			Expect(err).To(BeNil())
 		})
+
+		setEnv := func(instance *kedav1alpha1.KedaController, component string, env []corev1.EnvVar) error {
+			switch component {
+			case "operator":
+				instance.Spec.Operator.Env = env
+			case "metricsServer":
+				instance.Spec.MetricsServer.Env = env
+			case "admissionWebhooks":
+				instance.Spec.AdmissionWebhooks.Env = env
+			default:
+				return errors.New("Not a valid component: " + component)
+			}
+			return nil
+		}
 
 		// KEDA_HTTP_DEFAULT_TIMEOUT ships on all three containers, so it exercises the override
 		// path, while POD_NAMESPACE is a valueFrom variable the operator never touches.
@@ -414,32 +435,21 @@ var _ = Describe("Testing functionality", func() {
 		}
 
 		for _, variant := range variants {
-			caseName := fmt.Sprintf("Should set them on the '%s' container", variant.containerName)
+			caseName := fmt.Sprintf("Should set them on the '%s' container and drop them again once deleted", variant.containerName)
 			It(caseName, func() {
 				By(fmt.Sprintf("Setting %s.env in the kedaController manifest", variant.component))
-				env := []corev1.EnvVar{
-					{Name: "KEDA_HTTP_DEFAULT_TIMEOUT", Value: "10000"},
-					{Name: "KEDA_OLM_OPERATOR_TEST", Value: "example"},
-				}
-				manifest, err = mutateKedaController(manifest, scheme, caseName, func(instance *kedav1alpha1.KedaController) error {
-					switch variant.component {
-					case "operator":
-						instance.Spec.Operator.Env = env
-					case "metricsServer":
-						instance.Spec.MetricsServer.Env = env
-					case "admissionWebhooks":
-						instance.Spec.AdmissionWebhooks.Env = env
-					default:
-						return errors.New("Not a valid component: " + variant.component)
-					}
-					return nil
+				manifest, err = mutateKedaController(manifest, scheme, caseName+" (set)", func(instance *kedav1alpha1.KedaController) error {
+					return setEnv(instance, variant.component, []corev1.EnvVar{
+						{Name: "KEDA_HTTP_DEFAULT_TIMEOUT", Value: "10000"},
+						{Name: "KEDA_OLM_OPERATOR_TEST", Value: "example"},
+					})
 				})
 				Expect(err).To(BeNil())
 				Expect(manifest.Apply()).To(Succeed())
 
 				By("Waiting for the deployment to reflect the changes")
 				Eventually(func() error {
-					return deploymentHasRolledOut(variant.deploymentName, namespace, caseName)
+					return deploymentHasRolledOut(variant.deploymentName, namespace, caseName+" (set)")
 				}, timeout, interval).Should(Succeed())
 
 				u, err := getObject(ctx, "Deployment", variant.deploymentName, namespace, k8sClient)
@@ -460,9 +470,36 @@ var _ = Describe("Testing functionality", func() {
 				untouched, err := getDepEnv(dep, "POD_NAMESPACE", variant.containerName)
 				Expect(err).To(BeNil())
 				Expect(untouched.ValueFrom).ToNot(BeNil())
+
+				By(fmt.Sprintf("Deleting %s.env from the kedaController manifest", variant.component))
+				manifest, err = mutateKedaController(manifest, scheme, caseName+" (cleared)", func(instance *kedav1alpha1.KedaController) error {
+					return setEnv(instance, variant.component, nil)
+				})
+				Expect(err).To(BeNil())
+				Expect(manifest.Apply()).To(Succeed())
+
+				By("Waiting for the deployment to reflect the removal")
+				Eventually(func() error {
+					return deploymentHasRolledOut(variant.deploymentName, namespace, caseName+" (cleared)")
+				}, timeout, interval).Should(Succeed())
+
+				u, err = getObject(ctx, "Deployment", variant.deploymentName, namespace, k8sClient)
+				Expect(err).To(BeNil())
+				dep = &appsv1.Deployment{}
+				Expect(scheme.Convert(u, dep, nil)).To(Succeed())
+
+				By("Checking that the appended variable is gone")
+				_, err = getDepEnv(dep, "KEDA_OLM_OPERATOR_TEST", variant.containerName)
+				Expect(err).To(HaveOccurred())
+
+				By("Checking that the overridden variable is back to the value from the operand manifest")
+				restored, err := getDepEnv(dep, "KEDA_HTTP_DEFAULT_TIMEOUT", variant.containerName)
+				Expect(err).To(BeNil())
+				Expect(restored.Value).To(BeEmpty())
 			})
 		}
 	})
+
 })
 
 var _ = Describe("Testing audit flags", func() {

--- a/internal/controller/keda/kedacontroller_finalizer.go
+++ b/internal/controller/keda/kedacontroller_finalizer.go
@@ -4,33 +4,50 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	mf "github.com/manifestival/manifestival"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+	"github.com/kedacore/keda-olm-operator/internal/controller/keda/transform"
 )
 
 const (
 	kedaControllerFinalizer = "finalizer.kedacontroller.keda.sh"
 )
 
+// deleteOperand renders an untransformed operand manifest into the namespace it was
+// installed in and removes it.
+func (r *KedaControllerReconciler) deleteOperand(logger logr.Logger, manifest mf.Manifest, namespace, component string, extra ...mf.Transformer) error {
+	rendered, err := renderForDelete(manifest, namespace, extra...)
+	if err != nil {
+		logger.Info("error rendering KedaController manifest for deletion", "component", component, "error", err)
+		return err
+	}
+	if err := rendered.Delete(); err != nil {
+		logger.Info("error finalized KedaController "+component, "error", err)
+		return err
+	}
+	return nil
+}
+
 // finalizeKedaController is deleting resources for the respective KedaController
-func (r *KedaControllerReconciler) finalizeKedaController(logger logr.Logger) error {
-	if err := r.deleteHTTPAddon(logger); err != nil {
+func (r *KedaControllerReconciler) finalizeKedaController(logger logr.Logger, instance *kedav1alpha1.KedaController) error {
+	if err := r.deleteHTTPAddon(logger, instance.Namespace); err != nil {
 		logger.Info("error finalized KedaController HTTP Add-on", "error", err)
 		return err
 	}
 
-	if err := r.resourcesGeneral.Delete(); err != nil {
-		logger.Info("error finalized KedaController general", "error", err)
+	if err := r.deleteOperand(logger, r.resourcesGeneral, instance.Namespace, "general"); err != nil {
 		return err
 	}
-	if err := r.resourcesController.Delete(); err != nil {
-		logger.Info("error finalized KedaController controller", "error", err)
+	if err := r.deleteOperand(logger, r.resourcesController, instance.Namespace, "controller"); err != nil {
 		return err
 	}
-	if err := r.resourcesMetrics.Delete(); err != nil {
-		logger.Info("error finalized KedaController metrics", "error", err)
+	// the metrics server RoleBinding is installed into kube-system rather than the
+	// KedaController namespace, so it has to be pointed back there to be found
+	if err := r.deleteOperand(logger, r.resourcesMetrics, instance.Namespace, "metrics",
+		transform.ReplaceNamespace(roleBindingName, roleBindingNamespace, r.Scheme, logger)); err != nil {
 		return err
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,6 +10,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -157,6 +158,10 @@ func TestKedaControllerLifecycle(t *testing.T) {
 		for _, name := range coreDeployments {
 			waitForDeploymentGone(t, ctx, c, name)
 		}
+
+		// the metrics server RoleBinding is the only operand installed outside the
+		// KedaController namespace, so check that finalization reaches it too
+		waitForRoleBindingGone(t, ctx, c, "keda-auth-reader", "kube-system")
 	})
 }
 
@@ -227,6 +232,25 @@ func waitForDeploymentGone(t *testing.T, ctx context.Context, c client.Client, n
 	})
 	if err != nil {
 		t.Fatalf("deployment %s/%s was not deleted: %v", namespace, name, err)
+	}
+}
+
+func waitForRoleBindingGone(t *testing.T, ctx context.Context, c client.Client, name, ns string) {
+	t.Helper()
+	t.Logf("waiting for rolebinding %s/%s to be deleted", ns, name)
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		rb := &rbacv1.RoleBinding{}
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, rb); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("unexpected error checking rolebinding %s: %w", name, err)
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("rolebinding %s/%s was not deleted: %v", ns, name, err)
 	}
 }
 


### PR DESCRIPTION
The reconciler loads the operand manifests once at start-up, but each install then transformed them and stored the result back into `r.resources*`, so the next reconcile transformed an already-transformed manifest. The transformers only add or overwrite entries, never remove them, so anything deleted from the `KedaController` spec stayed in the cached desired state and kept being applied. Clearing a field had no effect until the operator process restarted.

This keeps the start-up manifests in new `pristine*` fields and transforms from those on every reconcile. `r.resources*` still holds the last applied result, which is what the finalizer deletes through.

Two properties of the existing code keep the change small:

- `manifestival.Transform` deep-copies (`result.resources = m.Resources()`), so the pristine manifests cannot be corrupted by a transform and need no defensive copying.
- Every install already begins its transform list with `InjectOwner` + `ReplaceAllNamespaces`, so transforming from pristine still yields a fully namespace-resolved manifest and the finalizer's delete paths are unchanged.

It also fixes both failure modes without touching any of the `if len(...) > 0` guards. Append-only transforms now only add what is currently in the spec, and guarded total-replacement transforms fall back to the operand manifest's value when the guard skips them, instead of to the previously applied value.

Affected fields are every spec-driven one, not just `env`: args, deployment annotations and labels, node selectors, tolerations, affinity, resource requirements, priority class names, and the network policy pod selectors.

This was reported by CodeRabbit while reviewing the `env` work in #335, but it is not a regression from that PR — the manifest caching long predates it.

### Testing

Added envtest removal coverage for all three components. Each spec sets `env`, waits for the rollout, deletes `env`, then asserts that the appended variable is gone **and** that `KEDA_HTTP_DEFAULT_TIMEOUT` is back to the empty value from `resources/keda.yaml`. That second assertion is the important one: it proves the desired state really returns to pristine rather than merely stopping at "didn't add anything new".

The suite's `BeforeEach` waits for the default `KedaController` to reach the client cache first, otherwise `Apply` races the operator creating it at start-up and fails with `kedacontrollers.keda.sh "keda" already exists`.

The full functionality suite fails three specs that need a real cluster with running pods (`Deploying KedaController manifest` and one annotation spec). A baseline run at `main` in a clean worktree fails the identical specs, so they are pre-existing under envtest.

### Note for reviewers

The behavior change is that clearing a spec field now actually takes effect. Any cluster relying on a value that was only surviving because of this bug will see it disappear on the first reconcile after upgrade.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
